### PR TITLE
default CrUX maxDate to latest in GCS

### DIFF
--- a/config/reports.json
+++ b/config/reports.json
@@ -563,6 +563,7 @@
 		],
 		"minDate": "2017_10_01",
 		"datePattern": ".*_01$",
+		"maxDateMetric": "cruxFcp",
 		"timeseries": {
 			"enabled": false
 		},

--- a/dates.py
+++ b/dates.py
@@ -16,3 +16,11 @@ def get_dates():
 			dates.append(match.group(0))
 	dates.sort(reverse=True)
 	return dates
+
+def get_latest_date(dates, metric_id):
+	gcs = storage.Client()
+	bucket = gcs.get_bucket(GCS_BUCKET)
+	for date in dates:
+		response = bucket.get_blob('reports/%s/%s.json' % (date, metric_id))
+		if response:
+			return date

--- a/docs/reports.md
+++ b/docs/reports.md
@@ -179,17 +179,9 @@ In this example config, there are two reports: Foo and Bar. They both include X 
 
         Optional string. Regular expression pattern of dates for which the report is available. For example, `".*_01$"` matches only the first crawl of the month.
 
-      - **minDate**
+      - **maxDateMetric**
 
-        Optional string. The earliest date at which the report is available. YYYY_MM_DD format.
-
-      - **maxDate**
-
-        Optional string. The latest date at which the report is available. YYYY_MM_DD format.
-
-      - **datePattern**
-
-        Optional string. Regular expression pattern of dates for which the report is available. For example, `".*_01$"` matches only the first crawl of the month.
+        Optional string. Metric ID used to query the GCS bucket. The maxDate for the report will be the most recent date-bucket that contains this metric's JSON results.
 
 ## Rendering a Report
 

--- a/main.py
+++ b/main.py
@@ -69,12 +69,15 @@ def report(report_id):
 	min_date = report.get('minDate')
 	max_date = report.get('maxDate')
 	date_pattern = report.get('datePattern')
+	max_date_metric = report.get('maxDateMetric')
 
 	# TODO: If a report doesn't explicitly have a min/max date,
 	# but all of its metrics do, take the min/max of the metrics
 	# and set that as the report's implicit min/max date.
 
 	# Omit dates for which this report has no data.
+	if max_date_metric:
+		max_date = report_util.get_latest_date(max_date_metric)
 	if min_date:
 		dates = dates[:dates.index(min_date) + 1]
 	if max_date:

--- a/reports.py
+++ b/reports.py
@@ -14,6 +14,7 @@ class VizTypes():
 MAX_REPORT_STALENESS = 60 * 60 * 3
 
 last_report_update = 0
+latest_metric_dates = {}
 report_dates = []
 reports_json = {}
 
@@ -28,6 +29,7 @@ def update_reports():
 	global reports_json
 
 	report_dates = dateutil.get_dates()
+	latest_metric_dates = {}
 
 	with open('config/reports.json') as reports_file:
 		reports_json = json.load(reports_file)
@@ -87,3 +89,14 @@ def get_similar_reports(metric_id, current_report_id):
 def get_dates():
 	global report_dates
 	return report_dates
+
+def get_latest_date(metric_id):
+	global report_dates
+	global latest_metric_dates
+	# Check the cache before hitting GCS.
+	latest_date = latest_metric_dates.get(metric_id)
+	if latest_date:
+		return latest_date
+	latest_date = dateutil.get_latest_date(report_dates, metric_id)
+	latest_metric_dates[metric_id] = latest_date
+	return latest_date


### PR DESCRIPTION
- new report config parameter `maxDateMetric`
- check param when setting up report JSON
- query GCS bucket to find latest date containing the metric
- cache latest date to prevent unnecessary lookups

We might want to consider a variation of this functionality for all reports, eg to omit dates from the Lighthouse report dropdowns when the metrics became unavailable in June.

Available for testing on staging: https://staging.httparchive.org/reports/chrome-ux-report

@igrigorik PTAL