### PR TITLE
Proposed fix for #57.

### DIFF
--- a/src/js/timeseries.js
+++ b/src/js/timeseries.js
@@ -54,7 +54,7 @@ function getSummary(data, options) {
 	const o = data[data.length - 1];
 	const summary = getPrimaryMetric(o, options);
 	const metric = new Metric(options, summary);
-	
+
 	return metric.toString();
 }
 
@@ -63,7 +63,16 @@ function getChange(data, options) {
 		return;
 	}
 
-	const oldest = getPrimaryMetric(data[0], options);
+	let oldestIndex;
+
+	for (let i = 0; i < data.length; i++) {
+		if (getPrimaryMetric(data[i], options) > 0) {
+			oldestIndex = i;
+			break;
+		}
+	}
+
+	const oldest = getPrimaryMetric(data[oldestIndex], options);
 	const latest = getPrimaryMetric(data[data.length - 1], options);
 
 	return (latest - oldest) * 100 / oldest;

--- a/src/js/timeseries.js
+++ b/src/js/timeseries.js
@@ -71,6 +71,10 @@ function getChange(data, options) {
 			break;
 		}
 	}
+	
+	if (oldestIndex === undefined) {
+		return;
+	}
 
 	const oldest = getPrimaryMetric(data[oldestIndex], options);
 	const latest = getPrimaryMetric(data[data.length - 1], options);


### PR DESCRIPTION
This contains a proposed fix for #57 where the relative change labels can read "Infinity%" if the initial value is `0`. Instead, this new code finds the first non-zero occurrence in the data set's primary metric and uses that as the starting value in lieu of `Infinity`.