### PR TITLE
support JSON APIs

### DIFF
--- a/reports.py
+++ b/reports.py
@@ -68,6 +68,8 @@ def get_metric(metric_id):
 	global reports_json
 	metrics = reports_json.get('_metrics')
 	metric = deepcopy(metrics.get(metric_id))
+	if not metric:
+		return None
 	metric['id'] = metric_id
 	return metric
 


### PR DESCRIPTION
Supported endpoints:

- /metric.json?id=metric_id
- /reports?f=json
- /report/report_id?f=json

@pmeenan this may be helpful for https://github.com/WPO-Foundation/webpagetest/issues/1133 and similar issues on WPT. You can use the new /metric.json API to look up the latest date for a given metric.

Request: `/metric.json?id=cruxFcp`
Response:
```json
{
  "latest": "2018_07_01", 
  "metric": {
    "description": "The number of seconds from the time the navigation started until the browser first renders. See the [Paint Timing API](https://w3c.github.io/paint-timing/#first-paint) for more info.", 
    "id": "cruxFcp", 
    "name": "First Contentful Paint", 
    "singular": "second", 
    "timeseries": {
      "enabled": false
    }, 
    "type": "seconds", 
    "wpt": {
      "path": "median$firstView$firstContentfulPaint", 
      "scale": 0.001
    }
  }, 
  "status": 200
}
```

The `latest` field indicates that you can fetch the latest CrUX FCP data at https://cdn.httparchive.org/reports/2018_07_01/cruxFcp.json

For CrUX metrics specifically, you can assume the `latest` date of YYYY_MM_DD will be valid until YYYY_MM+2_DD at the earliest. For example, 2018_07_01 will be the latest dataset until 2018_09_01, at which point the 2018_08_01 dataset may be released.

For all other metrics, the normal ~15 day freshness can be assumed.