### PR TITLE
Lens UI

### DIFF
--- a/csp.py
+++ b/csp.py
@@ -22,7 +22,8 @@ csp = {
 		'cdn.httparchive.org',
 		'discuss.httparchive.org',
 		'raw.githubusercontent.com',
-		'www.webpagetest.org'
+		'www.webpagetest.org',
+		'www.google-analytics.com'
 	],
 	'img-src': [
 		'\'self\'',

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -56,6 +56,13 @@ The HTTP Archive examines each URL in the list, but does not crawl the website's
 Most websites are comprised of many separate web pages. The landing page may not be representative of the overall site. Some websites, such as [facebook.com](http://www.facebook.com/), require logging in to see typical content. Some websites, such as [googleusercontent.com](http://www.googleusercontent.com/), don't have a landing page. Instead, they are used for hosting other URLs and resources. In this case googleusercontent.com is the domain path used for resources inserted by users into Google documents, etc. Because of these issues and more, it's possible that the actual HTML document analyzed is not representative of the website.
 
 
+### What is a lens?
+
+A lens focuses on a specific subset of websites. Through a lens, you'll see data about those particular websites only. For example, the [WordPress lens](https://wordpress.httparchive.org) focuses only on websites that are detected as being built with WordPress. We use [Wappalayzer](https://www.wappalyzer.com/) to detect over 1,000 web technologies and choose a few interesting ones to become lenses.
+
+Lenses can be enabled  at the top of any report, or by visiting the respective subdomain, for example [`wordpress.httparchive.org`](https://wordpress.httparchive.org).
+
+
 ### Who sponsors the HTTP Archive?
 
 The HTTP Archive is sponsored by companies large and small in the web industry who are dedicated to moving the web forward. Our sponsors make it possible for this non-profit project to continue operating and tracking how the web is built.

--- a/main.py
+++ b/main.py
@@ -123,6 +123,7 @@ def report(report_id):
 		dates = [d for d in dates if date_pattern.match(d)]
 
 	report['dates'] = dates
+	report['lenses'] = report_util.get_lenses()
 
 	start = request.args.get('start')
 	end = request.args.get('end')
@@ -167,10 +168,10 @@ def report(report_id):
 		if not request.args.get('start'):
 			start = dates[0]
 
-	lens = get_lens(request)
-
-	if report_util.is_valid_lens(lens):
-		report['lens'] = report_util.get_lens(lens)
+	lens_id = get_lens_id(request)
+	lens = report_util.get_lens(lens_id)
+	if lens:
+		report['lens'] = lens
 
 	# Determine which metrics should be enabled for this report.
 	for metric in report['metrics']:
@@ -178,7 +179,7 @@ def report(report_id):
 		metric['similar_reports'] = report_util.get_similar_reports(metric['id'], report_id)
 
 		# Mark the lens used for this metric, if applicable.
-		if lens and report_util.is_valid_lens(lens):
+		if lens:
 			metric['lens'] = lens
 
 		metric[viz] = metric.get(viz, {})
@@ -214,7 +215,7 @@ def report(report_id):
 						   start=start,
 						   end=end)
 
-def get_lens(request):
+def get_lens_id(request):
 	host = request.host.split('.')
 	subdomain = len(host) > 2 and host[0] or ''
 	return request.args.get('lens') or subdomain

--- a/reports.py
+++ b/reports.py
@@ -3,7 +3,7 @@ import logging
 from copy import deepcopy
 from time import time
 
-import dates as dateutil
+import dates as date_util
 
 
 class VizTypes():
@@ -28,7 +28,7 @@ def update_reports():
 	global report_dates
 	global reports_json
 
-	report_dates = dateutil.get_dates()
+	report_dates = date_util.get_dates()
 	latest_metric_dates = {}
 
 	with open('config/reports.json') as reports_file:
@@ -99,17 +99,22 @@ def get_latest_date(metric_id):
 	latest_date = latest_metric_dates.get(metric_id)
 	if latest_date:
 		return latest_date
-	latest_date = dateutil.get_latest_date(report_dates, metric_id)
+	latest_date = date_util.get_latest_date(report_dates, metric_id)
 	latest_metric_dates[metric_id] = latest_date
 	return latest_date
 
 def get_lenses():
 	global reports_json
+	# TODO: Consider sorting the lenses by name.
 	return reports_json.get('_lens', {})
 
-def get_lens(lens):
+def get_lens(lens_id):
 	lenses = get_lenses()
-	return lenses.get(lens, {})
+	lens = deepcopy(lenses.get(lens_id))
+	if not lens:
+		return None
+	lens['id'] = lens_id
+	return lens
 
 def is_valid_lens(lens):
 	lenses = get_lenses()

--- a/src/js/histogram.js
+++ b/src/js/histogram.js
@@ -9,7 +9,7 @@ const [COLOR_DESKTOP, COLOR_MOBILE, COLOR_DESKTOP_ALT, COLOR_MOBILE_ALT] = Color
 function histogram(metric, date, options) {
 	options.date = date;
 	options.metric = metric;
-	const dataUrl = `https://cdn.httparchive.org/reports/${options.lens ? `${options.lens}/` : ''}${date}/${metric}.json`;
+	const dataUrl = `https://cdn.httparchive.org/reports/${options.lens ? `${options.lens.id}/` : ''}${date}/${metric}.json`;
 	fetch(dataUrl)
 		.then(response => {
 			if (!response.ok) {
@@ -40,7 +40,7 @@ function drawClientSummary(data, options, client) {
 function getSummary(data, options) {
 	const summary = getPrimaryMetric(data, options);
 	const metric = new Metric(options, summary);
-	
+
 	return metric.toString();
 }
 
@@ -167,7 +167,7 @@ function drawHistogramTable(data, desktopId, mobileId, type, [start, end]=[-Infi
 			return drawHistogramTable(data, desktopId, mobileId, type, dateRange);
 		}, 100);
 	}
-	
+
 	const bins = data.filter(data => {
 		return data.bin >= start && data.bin <= end
 	}).map(data => new Bin(data));
@@ -281,7 +281,7 @@ function drawChart(series, containerId, options) {
 			}
 		},
 		title: {
-			text: `Histogram of ${options.name}`
+			text: `${options.lens ? `${options.lens.name}: ` : '' }` + `Histogram of ${options.name}`
 		},
 		subtitle: {
 			text: `Source: <a href="http://httparchive.org">httparchive.org</a> (${prettyDate(options.date)})`,
@@ -324,7 +324,7 @@ function drawChart(series, containerId, options) {
 						<p style="color: ${point.color.replace('0.4', '1')}; font-size: 20px;">
 							${(point.y).toFixed(2)}%
 						</p>
-						${cdf ? 
+						${cdf ?
 						`<p style="text-transform: uppercase; font-size: 8px; color: #777;">
 							Cumulative
 						</p>

--- a/src/js/report.js
+++ b/src/js/report.js
@@ -10,9 +10,11 @@ class Report {
 		this.report = report;
 		this.viz = viz;
 		this.baseUrl = report.url;
+		this.lens = report.lens && report.lens.id;
 		this.startDate = report.startDate;
 		this.endDate = report.endDate;
 
+		this.bindChangeListener('lens');
 		this.bindChangeListener('startDate');
 		this.bindChangeListener('endDate');
 		this.bindUpdateListener();
@@ -80,12 +82,21 @@ class Report {
 	}
 
 	updatePermalink() {
+		const url = new URL(this.baseUrl);
+		const lens = this.lens;
+
+		// TODO: Change subdomain.
+		if (lens) {
+			url.searchParams.set('lens', lens);
+		} else {
+			url.searchParams.delete('lens');
+		}
+
 		if (this.isOneYearAgo(this.startDate) && this.isLatest(this.endDate)) {
-			this.permalink.value = this.baseUrl;
+			this.permalink.value = url.toString();
 			return;
 		}
 
-		const url = new URL(this.baseUrl);
 		const start = this.getDateUrlAlias(this.startDate);
 		const end = this.getDateUrlAlias(this.endDate);
 

--- a/src/js/timeseries.js
+++ b/src/js/timeseries.js
@@ -6,7 +6,7 @@ import { el, prettyDate, chartExportOptions, drawMetricSummary } from './utils';
 
 
 function timeseries(metric, options, start, end) {
-	const dataUrl = `https://cdn.httparchive.org/reports/${options.lens ? `${options.lens}/` : ''}${metric}.json`;
+	const dataUrl = `https://cdn.httparchive.org/reports/${options.lens ? `${options.lens.id}/` : ''}${metric}.json`;
 	options.chartId = `${metric}-chart`;
 	options.tableId = `${metric}-table`;
 	options.metric = metric;
@@ -278,7 +278,7 @@ function drawChart(options, series) {
 			zoomType: 'x'
 		},
 		title: {
-			text: `Timeseries of ${options.name}`
+			text: `${options.lens ? `${options.lens.name}: ` : '' }` + `Timeseries of ${options.name}`
 		},
 		subtitle: {
 			text: 'Source: <a href="http://httparchive.org">httparchive.org</a>',

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -287,6 +287,14 @@ input {
 	border-bottom-style: solid;
 }
 
+.help-tooltip {
+	opacity: 0.7;
+	transition: all 0.2s;
+}
+.help-tooltip:hover {
+	opacity: 1.0;
+}
+
 
 @media (max-width: 992px) {
 	footer {

--- a/templates/report/report.html
+++ b/templates/report/report.html
@@ -43,9 +43,11 @@
 							<div class="col-sm-8 col-sm-offset-2 col-xs-12">
 								<label for="lens">
 									Lens
-										<i
-											class="hidden-xs help-tooltip fa fa-info-circle"
-											title="A lens shows a report for a particular subset of websites."></i>
+										<a href="{{ url_for('faq', _anchor='what-is-a-lens') }}">
+											<i
+												class="hidden-xs help-tooltip fa fa-info-circle"
+												title="A lens shows a report for a particular subset of websites."></i>
+										</a>
 								</label>
 
 								<select id="lens">

--- a/templates/report/report.html
+++ b/templates/report/report.html
@@ -2,6 +2,7 @@
 
 
 {% set wpt_id = request.args.get('wptid') %}
+{% set enabled_lens_id = report.lens.id if report.lens else '' %}
 
 {% block title %}{{ (report.lens and '%s: ' % report.lens.name or '') +report.name }}{% endblock %}
 
@@ -39,6 +40,24 @@
 
 					<div class="col-lg-8 col-md-8 col-sm-12 col-xs-12">
 						<form id="history" class="row">
+							<div class="col-sm-8 col-sm-offset-2 col-xs-12">
+								<label for="lens">
+									Lens
+										<i
+											class="hidden-xs help-tooltip fa fa-info-circle"
+											title="A lens shows a report for a particular subset of websites."></i>
+								</label>
+
+								<select id="lens">
+									<option></option>
+									{% for (lens_id, l) in report.lenses.items() %}
+										<option value="{{ lens_id }}" {% if lens_id == enabled_lens_id %}selected{% endif %}>
+											{{ l.name }}
+										</option>
+									{% endfor %}
+								</select>
+							</div>
+
 							<div class="col-sm-4 col-sm-offset-2 col-xs-12">
 								<label for="startDate">
 									Start Date
@@ -57,14 +76,9 @@
 								<label for="endDate" title="Optional">
 									End Date
 								</label>
-								
+
 								<select id="endDate">
 									<option></option>
-									{% if end == report.dates[0] %}
-										<option value="{{ report.dates[0] }}">
-											Most Recent
-										</option>
-									{% endif %}
 									{% for d in report.dates %}
 										<option value="{{ d }}" {% if d == end %}selected{% endif %} class="yyyy_mm_dd">
 											{{ d }}
@@ -89,7 +103,7 @@
 					</div>
 				</div>
 			</div>
-		</div>	
+		</div>
 	</section>
 
 	<section id="report-metrics">


### PR DESCRIPTION
Progress on https://github.com/HTTPArchive/httparchive.org/issues/40 UI to add/remove lenses.

Lenses are surfaced in the following UI:
- in the subdomain or querystring params of the URL (for permalinking)
- prefacing the report name on report pages (as FYI)
- in the permalink form on report pages (for adding/removing lenses)
- in individual chart titles (to disambiguate screenshots)

![image](https://user-images.githubusercontent.com/1120896/44171627-acde4d80-a0a8-11e8-88e9-2a1ff6fd3670.png)

The field in the permalink form is a dropdown with an empty option (no lens), and an option for each lens name. Selecting an option will automatically update the permalink with the appropriate lens URL param. Clicking "Update" will reload the page with the lens enabled or disabled. I also added an "i" tooltip to describe what a lens is and hide it on mobile, where this is no mouseover.

It doesn't currently mess around with the subdomains. Stacking a `?lens=drupal` on top of `wordpress.httparchive.org` in this UI will set the lens to Drupal. Ideally it would drop the URL param and change the host to `drupal.httparchive.org`, but it seems ok for now. I left a TODO in the code.

The ordering of the lenses is non-deterministic. Also left a TODO to sort them.