### PR TITLE
Make the charts taller

### DIFF
--- a/static/css/report.css
+++ b/static/css/report.css
@@ -143,7 +143,7 @@ th {
 
 .chart {
 	min-width: 310px;
-	height: 400px;
+	height: 600px;
 	margin: 0 auto;
 }
 


### PR DESCRIPTION
This probably should have started with some discussion rather than the PR, but it was so easy!

Whenever I'm looking at HA charts, the lack of vertical height makes it harder for me to see the changes over time. This PR just makes the charts 50% taller.

Before and after:
![image](https://user-images.githubusercontent.com/39191/45241956-2aaa0900-b2a3-11e8-8461-d60774b40357.png)


wdyt?