### PR TITLE
minor layout fix

### DIFF
--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -383,11 +383,11 @@ input {
 }
 
 @media (min-width: 768px) {
-	.container-flex {
+	.flex-container {
 		display: flex;
 	}
 
-	.container-flex.align-middle {
+	.flex-align-middle {
 		align-items: center;
 	}
 }

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -19,9 +19,6 @@ footer {
 header [class*="col"],
 footer [class*="col"],
 section [class*="col"] {
-	display: inline-block;
-	float: none;
-	margin-right: -4px;
 	vertical-align: middle;
 }
 .container {

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -382,6 +382,16 @@ input {
 	}
 }
 
+@media (min-width: 768px) {
+	.container-flex {
+		display: flex;
+	}
+
+	.container-flex.align-middle {
+		align-items: center;
+	}
+}
+
 #sponsor-logos {
 	background-color: #fff;
 	border: 1px solid #748c8f;

--- a/templates/index.html
+++ b/templates/index.html
@@ -10,7 +10,7 @@
 
 {% block main %}
 	<section id="how-web-is-built" class="container">
-		<div class="col-lg-5 col-sm-5 col-md-5 col-xs-6">
+		<div class="col-lg-5 col-md-5 col-sm-5 col-xs-6 col-xs-offset-3 col-sm-offset-0">
 			<a href="{{ url_for('reports') }}">
 				<img src="/static/img/web.png" alt="" aria-label="HTTP Archive reports"/>
 			</a>

--- a/templates/index.html
+++ b/templates/index.html
@@ -9,7 +9,7 @@
 {% endblock %}
 
 {% block main %}
-	<section id="how-web-is-built" class="container container-flex align-middle">
+	<section id="how-web-is-built" class="container flex-container flex-align-middle">
 		<div class="col-lg-5 col-md-5 col-sm-5 col-xs-6 col-xs-offset-3 col-sm-offset-0">
 			<a href="{{ url_for('reports') }}">
 				<img src="/static/img/web.png" alt="" aria-label="HTTP Archive reports"/>
@@ -54,11 +54,11 @@
 	</section>
 
 	<section id="bigquery" class="container">
-		<div class="row">
-			<h2>
-				<small>Public Dataset</small>
-				Google BigQuery
-			</h2>
+		<h2>
+			<small>Public Dataset</small>
+			Google BigQuery
+		</h2>
+		<div class="row flex-container flex-align-middle">
 			<div class="col-lg-6 col-sm-6 col-md-6 col-xs-12">
 
 				<p>

--- a/templates/index.html
+++ b/templates/index.html
@@ -9,7 +9,7 @@
 {% endblock %}
 
 {% block main %}
-	<section id="how-web-is-built" class="container">
+	<section id="how-web-is-built" class="container container-flex align-middle">
 		<div class="col-lg-5 col-md-5 col-sm-5 col-xs-6 col-xs-offset-3 col-sm-offset-0">
 			<a href="{{ url_for('reports') }}">
 				<img src="/static/img/web.png" alt="" aria-label="HTTP Archive reports"/>

--- a/templates/main.html
+++ b/templates/main.html
@@ -93,7 +93,7 @@
 	</div>
 
 	<footer>
-		<div class="container">
+		<div class="container flex-container flex-align-middle">
 			<div class="col-lg-5 col-md-6 col-sm-12 col-xs-12">
 				<a href="{{ url_for('index') }}">
 					<img class="logo" src="/static/img/ha.png" alt="HTTP Archive"/></a>


### PR DESCRIPTION
Removing the `margin` from the columns make each column centered to the view on smaller viewport. It also makes use of the `float` instead of changing the display to `inline-block`, so it keeps the Bootstrap layout system.

Example 1:
![kapture 2018-09-08 at 12 34 38](https://user-images.githubusercontent.com/1531291/45256916-4bd62c80-b36b-11e8-8d44-5f8d380c01bc.gif)

Example 2:
![kapture 2018-09-08 at 12 22 24](https://user-images.githubusercontent.com/1531291/45256917-4bd62c80-b36b-11e8-9f2d-dcda7418144a.gif)
