### PR TITLE
Faster animation for transition

### DIFF
--- a/static/css/index.css
+++ b/static/css/index.css
@@ -37,7 +37,7 @@
 }
 .discussion-users li + li {
 	margin-left: -12px;
-	transition: margin-left .8s;
+	transition: margin-left .2s;
 }
 .discussion-users:hover li + li {
 	margin-left: 0;


### PR DESCRIPTION
I feel like on the discussion animation (hover) should be a little faster to make this a little bit smoother.

Currently:

![](https://user-images.githubusercontent.com/1531291/45260185-39c9ad80-b3ae-11e8-986d-4854c8a4748a.gif)

Updated:

![](https://user-images.githubusercontent.com/1531291/45260191-477f3300-b3ae-11e8-917b-442219c5a424.gif)

It also matches the `.help-tooltip` transition duration.