### PR TITLE
Fix importing urlparse in python 3

### DIFF
--- a/main.py
+++ b/main.py
@@ -16,7 +16,10 @@
 import logging
 import re
 from time import time
-from urlparse import urlparse
+try:
+    from urllib.parse import urlparse
+except ImportError:
+    from urlparse import urlparse
 
 from csp import csp
 import reports as report_util


### PR DESCRIPTION
Running the server using Python 3 throws an error as it can't find the `urlparse` module.

I came across the same issue here: https://github.com/heroku/kafka-helper/issues/6 (with the solution)

Is there a python version requirement for the project?

Ref: #88 