### PR TITLE
Pull changelog.json from cdn.rawgit

### DIFF
--- a/csp.py
+++ b/csp.py
@@ -21,7 +21,7 @@ csp = {
 		'\'self\'',
 		'cdn.httparchive.org',
 		'discuss.httparchive.org',
-		'raw.githubusercontent.com',
+		'cdn.rawgit.com',
 		'www.webpagetest.org',
 		'www.google-analytics.com',
 		'stats.g.doubleclick.net'

--- a/src/js/changelog.js
+++ b/src/js/changelog.js
@@ -1,7 +1,7 @@
 export default class Changelog {
 
 	static get URL() {
-		return 'https://raw.githubusercontent.com/HTTPArchive/httparchive/master/docs/changelog.json';
+		return 'https://cdn.rawgit.com/HTTPArchive/httparchive/master/docs/changelog.json';
 	}
 
 }

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -59,7 +59,7 @@ export const drawMetricSummary = (options, client, value, isMedian=true, change=
 };
 
 const getQueryUrl = (metric, type) => {
-	const URL_BASE = 'https://raw.githubusercontent.com/HTTPArchive/bigquery/master/sql';
+	const URL_BASE = 'https://cdn.rawgit.com/HTTPArchive/bigquery/master/sql';
 	if (type === 'timeseries') {
 		return `${URL_BASE}/timeseries/${metric}.sql`;
 	}


### PR DESCRIPTION
We noticed some  503's that caused the graphs to not load. Hypothetically this avoids the 503s. thx https://rawgit.com/

timeseries.js should probably also assume this fetch _could_ fail and still render the graphs anyway.