### PR TITLE
add a 3y button to timeseries charts

### DIFF
--- a/src/js/timeseries.js
+++ b/src/js/timeseries.js
@@ -347,6 +347,35 @@ function drawChart(options, series) {
 				${getChangelog(changelog)}`;
 			}
 		},
+		rangeSelector: {
+			buttons: [{
+		    type: 'month',
+		    count: 1,
+		    text: '1m'
+			}, {
+		    type: 'month',
+		    count: 3,
+		    text: '3m'
+			}, {
+		    type: 'month',
+		    count: 6,
+		    text: '6m'
+			}, {
+		    type: 'ytd',
+		    text: 'YTD'
+			}, {
+		    type: 'year',
+		    count: 1,
+		    text: '1y'
+			}, {
+		    type: 'year',
+		    count: 3,
+		    text: '3y'
+			}, {
+		    type: 'all',
+		    text: 'All'
+			}]
+		},
 		xAxis: {
 			type: 'datetime',
 			events: {


### PR DESCRIPTION
Now that timeseries default to 3 years, make sure there's an appropriate zoom button. Closes #82.

![image](https://user-images.githubusercontent.com/1120896/47609685-647ccd80-da11-11e8-9fac-67cc9e69f2df.png)
