### PR TITLE
Improve Tablet Navigation

### DIFF
--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -43,7 +43,6 @@ nav li {
 }
 nav li a,
 nav li .dropdown-target {
-	cursor: pointer;
 	display: inherit;
 	padding: 12px 20px;
 }

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -43,6 +43,7 @@ nav li {
 }
 nav li a,
 nav li .dropdown-target {
+	cursor: pointer;
 	display: inherit;
 	padding: 12px 20px;
 }

--- a/templates/main.html
+++ b/templates/main.html
@@ -36,12 +36,13 @@
 				<nav class="hidden-xs pull-right text-right">
 					<ul>
 						<li>
-							<a class="dropdown-target" aria-haspopup="true" href="{{ url_for('reports') }}">
+							<a class="dropdown-target" aria-haspopup="true">
 								Reports
 								<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 18 18"><path d="M5 8l4 4 4-4z"/></svg>
 							</a>
 							
 							<ul class="dropdown-content reports">
+								<li><a href="{{ url_for('reports') }}">All Reports</a></li>
 								{% for report in reports %}
 									<li>
 										<a href="{{ url_for('report', report_id=report.id) }}">
@@ -55,7 +56,7 @@
 							<a href="https://discuss.httparchive.org">Discuss</a>
 						</li>
 						<li>
-							<a class="dropdown-target" aria-haspopup="true" href="{{ url_for('about') }}">
+							<a class="dropdown-target" aria-haspopup="true">
 								About
 								<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 18 18"><path d="M5 8l4 4 4-4z"/></svg>
 							</a>

--- a/templates/main.html
+++ b/templates/main.html
@@ -36,10 +36,10 @@
 				<nav class="hidden-xs pull-right text-right">
 					<ul>
 						<li>
-							<a class="dropdown-target" aria-haspopup="true">
+							<span class="dropdown-target" aria-haspopup="true">
 								Reports
 								<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 18 18"><path d="M5 8l4 4 4-4z"/></svg>
-							</a>
+							</span>
 							
 							<ul class="dropdown-content reports">
 								<li><a href="{{ url_for('reports') }}">All Reports</a></li>
@@ -56,10 +56,10 @@
 							<a href="https://discuss.httparchive.org">Discuss</a>
 						</li>
 						<li>
-							<a class="dropdown-target" aria-haspopup="true">
+							<span class="dropdown-target" aria-haspopup="true">
 								About
 								<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 18 18"><path d="M5 8l4 4 4-4z"/></svg>
-							</a>
+							</span>
 							
 							<ul class="dropdown-content">
 								<li>


### PR DESCRIPTION
In the end, I went for a simpler way than initially proposed. Open-on-click navigational menus pose their own challenges (Do they have to close on click-away?), so I left them as open-on-hover/focus and just removed the links of the dropdown targets.