### PR TITLE
Add exception handling for failed auth to GCS

### DIFF
--- a/dates.py
+++ b/dates.py
@@ -1,10 +1,62 @@
 import re
+import logging
+
 from google.cloud import storage
+from google.auth.exceptions import DefaultCredentialsError
+
+# Create/configure stream handler
+sh = logging.StreamHandler()
+fmt = logging.Formatter('%(name)s.py - %(levelname)s - %(message)s')
+sh.setFormatter(fmt)
+
+# Register stream handler
+logger = logging.getLogger(__name__)
+logger.addHandler(sh)
 
 GCS_BUCKET = 'httparchive'
 
-def get_dates():
+# When running the site locally and unable to authenticate with GCS bypass
+# loading dates from GCS.
+LOAD_DATES_FROM_GCS = True
+try:
 	gcs = storage.Client()
+except DefaultCredentialsError:
+	logger.warning('Unable to authenticate to Google Cloud Storage.')
+	LOAD_DATES_FROM_GCS = False
+
+	def mock_get_dates(start_year, end_year, today, month_delta=0):
+		''' Generate mock dates to the format the site frontend expects them'''
+		year = start_year
+		months = []
+		for month in range(1, ((end_year - start_year) * 12) + (month_delta + 1)):
+			current_month_in_year = month % 12
+			if current_month_in_year == 0:
+				current_month_in_year = 12
+
+			if current_month_in_year < 10:
+				current_month_in_year = "0{}".format(current_month_in_year)
+
+			months.append('{}_{}_01'.format(year, current_month_in_year))
+			if year == end_year and current_month_in_year == month_delta and today < 15:
+				continue
+			months.append('{}_{}_15'.format(year, current_month_in_year))
+
+			if month % 12 == 0:
+				year = year + 1
+
+		months.sort(reverse=True)
+		return months
+
+	# Setup the mock dates
+	import datetime
+	now = datetime.datetime.now()
+	mock_dates = mock_get_dates(2010, now.year, now.day, now.month)
+
+def get_dates():
+	if not LOAD_DATES_FROM_GCS:
+		logger.warning('Google Cloud Storage disabled, using mock_get_dates()')
+		return mock_dates
+
 	bucket = gcs.get_bucket(GCS_BUCKET)
 	iterator = bucket.list_blobs(prefix='reports/20', delimiter='/')
 	response = iterator._get_next_page_response()
@@ -18,7 +70,10 @@ def get_dates():
 	return dates
 
 def get_latest_date(dates, metric_id):
-	gcs = storage.Client()
+	if not LOAD_DATES_FROM_GCS:
+		logger.warning('Google Cloud Storage disabled, using mock_get_latest_date')
+		return mock_dates[0]
+
 	bucket = gcs.get_bucket(GCS_BUCKET)
 	for date in dates:
 		response = bucket.get_blob('reports/%s/%s.json' % (date, metric_id))


### PR DESCRIPTION
This should fix issue [Allow local building without gcloud](https://github.com/HTTPArchive/httparchive.org/issues/87) when `GOOGLE_APPLICATION_CREDENTIALS` are not configured locally. Instead of adding a build flag, this just catches the exception raised when authentication fails and sets a flag to not load the gcs bucket.

I added a custom logger to `dates.py` so when developing you can easily see when the site isn't loading dates from GCS.

```
dates.py - WARNING - Unable to authenticate to Google Cloud Storage.
dates.py - WARNING - Google Cloud Storage disabled, skipping get_dates()
```

Additionally, I couldn't decide on an elegant way to fail the route `/reports/<report_id>` since it requires dates to be available, so I log a message to console (`WARNING:root:Unable to load dates from GCS`) and aborts with a 500, open to suggestions on this.

This will probably need to be tested in GAE flex to make sure I didn't break anything :)