### PR TITLE
update FAQ to monthly

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -9,12 +9,12 @@
 
 ### How does the HTTP Archive decide which URLs to test?
 
-The HTTP Archive crawls [1M+ URLs](https://httparchive.org/reports/state-of-the-web#numUrls) on both desktop and mobile twice a month. The URLs come from the Chrome User Experience Report, a monthly dataset of real user performance data of the most popular websites. Only the URLs whose domain is in the [Alexa Top 1,000,000](http://www.alexa.com/topsites) ranked list are included.
+The HTTP Archive crawls [millions of URLs](https://httparchive.org/reports/state-of-the-web#numUrls) on both desktop and mobile monthly. The URLs come from the [Chrome User Experience Report](https://web.dev/fast/chrome-ux-report), a dataset of real user performance data of the most popular websites.
 
 
 ### How is the data gathered?
 
-The list of URLs is fed to our private instance of [WebPageTest](https://webpagetest.org) on the 1st and 15th of each month.
+The list of URLs is fed to our private instance of [WebPageTest](https://webpagetest.org) on the 1st of each month.
 
 As of March 1 2016, the tests are performed on Chrome for desktop and emulated Android (on Chrome) for mobile.
 


### PR DESCRIPTION
Fixes #129 

Before:

```
How does the HTTP Archive decide which URLs to test?
The HTTP Archive crawls 1M+ URLs on both desktop and mobile twice a month.
The URLs come from the Chrome User Experience Report, a monthly dataset of 
real user performance data of the most popular websites. Only the URLs whose 
domain is in the Alexa Top 1,000,000 ranked list are included.

How is the data gathered?
The list of URLs is fed to our private instance of WebPageTest on the 1st and 15th
 of each month.
```


After:

```
How does the HTTP Archive decide which URLs to test?
The HTTP Archive crawls millions of URLs on both desktop and mobile monthly. 
The URLs come from the Chrome User Experience Report, a dataset of real user 
performance data of the most popular websites.

How is the data gathered?
The list of URLs is fed to our private instance of WebPageTest on the 1st of 
each month.
```