### PR TITLE
Add Project Fugu report

### DIFF
--- a/config/reports.json
+++ b/config/reports.json
@@ -818,7 +818,7 @@
 			}
 		},
 		"shapeDetectionFace": {
-			"name": "(🏁 Behind flag) Shape Detection (Face)",
+			"name": "(🚩 Behind flag) Shape Detection (Face)",
 			"type": "%",
 			"downIsBad": true,
 			"description": "This metric tracks the percentage of pages that use the face detector via the [Shape Detection API](https://web.dev/shape-detection/).",
@@ -832,7 +832,7 @@
 			}
 		},
 		"shapeDetectionText": {
-			"name": "(🏁 Behind flag) Shape Detection (Text)",
+			"name": "(🚩 Behind flag) Shape Detection (Text)",
 			"type": "%",
 			"downIsBad": true,
 			"description": "This metric tracks the percentage of pages that use the text detector via the [Shape Detection API](https://web.dev/shape-detection/).",
@@ -888,10 +888,52 @@
 			}
 		},
 		"notificationTriggers": {
-			"name": "(🏁 Behind flag) Notification Triggers",
+			"name": "(🚩 Behind flag) Notification Triggers",
 			"type": "%",
 			"downIsBad": true,
 			"description": "This metric tracks the percentage of pages that use scheduled notifications via the [Notification Triggers API](https://web.dev/notification-triggers/).",
+			"histogram": {
+				"enabled": false
+			},
+			"timeseries": {
+				"fields": [
+					"percent"
+				]
+			}
+		},
+		"webNFCRead": {
+			"name": "(🧪 Origin trial) Web NFC",
+			"type": "%",
+			"downIsBad": true,
+			"description": "This metric tracks the percentage of pages that *read* NFC tags via the [Web NFC API](https://web.dev/nfc/).",
+			"histogram": {
+				"enabled": false
+			},
+			"timeseries": {
+				"fields": [
+					"percent"
+				]
+			}
+		},
+		"webNFCWrite": {
+			"name": "(🧪 Origin trial) Web NFC",
+			"type": "%",
+			"downIsBad": true,
+			"description": "This metric tracks the percentage of pages that *write* NFC tags via the [Web NFC API](https://web.dev/nfc/).",
+			"histogram": {
+				"enabled": false
+			},
+			"timeseries": {
+				"fields": [
+					"percent"
+				]
+			}
+		},
+		"screenWakeLock": {
+			"name": "(🐡 Launched) Screen Wake Lock",
+			"type": "%",
+			"downIsBad": true,
+			"description": "This metric tracks the percentage of pages that acquire a screen wake lock via the [Screen Wake Lock API](https://web.dev/wakelock/).",
 			"histogram": {
 				"enabled": false
 			},
@@ -1123,7 +1165,10 @@
 			"webOTP",
 			"webShareContainingFiles",
 			"webShareNoFiles",
-			"notificationTriggers"
+			"notificationTriggers",
+			"webNFCRead",
+			"webNFCWrite",
+			"screenWakeLock"
 		],
 		"graphic": {
 			"bgcolor": "#97b5b9",

--- a/config/reports.json
+++ b/config/reports.json
@@ -692,7 +692,7 @@
 			}
 		},
 		"asyncClipboardRead": {
-			"name": "Async Clipboard Read",
+			"name": "(🐡 Launched) Async Clipboard Read",
 			"type": "%",
 			"downIsBad": true,
 			"description": "This metric tracks the percentage of pages that *read* data from the system clipboard via the [Async Clipboard API](https://web.dev/image-support-for-async-clipboard/).",
@@ -706,7 +706,7 @@
 			}
 		},
 		"asyncClipboardWrite": {
-			"name": "Async Clipboard Write",
+			"name": "(🐡 Launched) Async Clipboard Write",
 			"type": "%",
 			"downIsBad": true,
 			"description": "This metric tracks the percentage of pages that *write* data to the system clipboard via the [Async Clipboard API](https://web.dev/image-support-for-async-clipboard/).",
@@ -720,7 +720,7 @@
 			}
 		},
 		"badgeSet": {
-			"name": "Badge Set",
+			"name": "(🐡 Launched) Badge Set",
 			"type": "%",
 			"downIsBad": true,
 			"description": "This metric tracks the percentage of pages that *set* a badge via the [Badging API](https://web.dev/badging-api/).",
@@ -734,7 +734,7 @@
 			}
 		},
 		"badgeClear": {
-			"name": "Badge Clear",
+			"name": "(🐡 Launched) Badge Clear",
 			"type": "%",
 			"downIsBad": true,
 			"description": "This metric tracks the percentage of pages that *clear* a badge via the [Badging API](https://web.dev/badging-api/).",
@@ -748,7 +748,7 @@
 			}
 		},
 		"contactPicker": {
-			"name": "Contact Picker",
+			"name": "(🐡 Launched) Contact Picker",
 			"type": "%",
 			"downIsBad": true,
 			"description": "This metric tracks the percentage of pages that access contacts via the [Contact Picker API](https://web.dev/contact-picker/).",
@@ -762,10 +762,136 @@
 			}
 		},
 		"getInstalledRelatedApps": {
-			"name": "Get Installed Related Apps",
+			"name": "(🐡 Launched) Get Installed Related Apps",
 			"type": "%",
 			"downIsBad": true,
 			"description": "This metric tracks the percentage of pages that get the installed related apps via the [Get Installed Related Apps API](https://web.dev/get-installed-related-apps/).",
+			"histogram": {
+				"enabled": false
+			},
+			"timeseries": {
+				"fields": [
+					"percent"
+				]
+			}
+		},
+		"periodicBackgroundSync": {
+			"name": "(🐡 Launched) Periodic Background Sync",
+			"type": "%",
+			"downIsBad": true,
+			"description": "This metric tracks the percentage of pages that observe a `periodicsync` event that was registered via the [Periodic Background Sync API](https://web.dev/periodic-background-sync/).",
+			"histogram": {
+				"enabled": false
+			},
+			"timeseries": {
+				"fields": [
+					"percent"
+				]
+			}
+		},
+		"periodicBackgroundSyncRegister": {
+			"name": "(🐡 Launched) Periodic Background Sync Register",
+			"type": "%",
+			"downIsBad": true,
+			"description": "This metric tracks the percentage of pages that register a `periodicsync` event via the [Periodic Background Sync API](https://web.dev/periodic-background-sync/).",
+			"histogram": {
+				"enabled": false
+			},
+			"timeseries": {
+				"fields": [
+					"percent"
+				]
+			}
+		},
+		"shapeDetectionBarcode": {
+			"name": "(🐡 Launched) Shape Detection (Barcode)",
+			"type": "%",
+			"downIsBad": true,
+			"description": "This metric tracks the percentage of pages that use the barcode detector via the [Shape Detection API](https://web.dev/shape-detection/).",
+			"histogram": {
+				"enabled": false
+			},
+			"timeseries": {
+				"fields": [
+					"percent"
+				]
+			}
+		},
+		"shapeDetectionFace": {
+			"name": "(🏁 Behind flag) Shape Detection (Face)",
+			"type": "%",
+			"downIsBad": true,
+			"description": "This metric tracks the percentage of pages that use the face detector via the [Shape Detection API](https://web.dev/shape-detection/).",
+			"histogram": {
+				"enabled": false
+			},
+			"timeseries": {
+				"fields": [
+					"percent"
+				]
+			}
+		},
+		"shapeDetectionText": {
+			"name": "(🏁 Behind flag) Shape Detection (Text)",
+			"type": "%",
+			"downIsBad": true,
+			"description": "This metric tracks the percentage of pages that use the text detector via the [Shape Detection API](https://web.dev/shape-detection/).",
+			"histogram": {
+				"enabled": false
+			},
+			"timeseries": {
+				"fields": [
+					"percent"
+				]
+			}
+		},
+		"webOTP": {
+			"name": "(🐡 Launched) Web OTP",
+			"type": "%",
+			"downIsBad": true,
+			"description": "This metric tracks the percentage of pages that receive a one-time password (OTP) via the [Web OTP API](https://web.dev/sms-receiver-api-announcement/).",
+			"histogram": {
+				"enabled": false
+			},
+			"timeseries": {
+				"fields": [
+					"percent"
+				]
+			}
+		},
+		"webShareContainingFiles": {
+			"name": "(🐡 Launched) Web Share (Containing Files)",
+			"type": "%",
+			"downIsBad": true,
+			"description": "This metric tracks the percentage of pages that share files via the [Web Share API](https://web.dev/web-share/).",
+			"histogram": {
+				"enabled": false
+			},
+			"timeseries": {
+				"fields": [
+					"percent"
+				]
+			}
+		},
+		"webShareNoFiles": {
+			"name": "(🐡 Launched) Web Share (No Files)",
+			"type": "%",
+			"downIsBad": true,
+			"description": "This metric tracks the percentage of pages that share text via the [Web Share API](https://web.dev/web-share/).",
+			"histogram": {
+				"enabled": false
+			},
+			"timeseries": {
+				"fields": [
+					"percent"
+				]
+			}
+		},
+		"notificationTriggers": {
+			"name": "(🏁 Behind flag) Notification Triggers",
+			"type": "%",
+			"downIsBad": true,
+			"description": "This metric tracks the percentage of pages that use scheduled notifications via the [Notification Triggers API](https://web.dev/notification-triggers/).",
 			"histogram": {
 				"enabled": false
 			},
@@ -988,7 +1114,16 @@
 			"badgeSet",
 			"badgeClear",
 			"contactPicker",
-			"getInstalledRelatedApps"
+			"getInstalledRelatedApps",
+			"periodicBackgroundSyncRegister",
+			"periodicBackgroundSync",
+			"shapeDetectionBarcode",
+			"shapeDetectionFace",
+			"shapeDetectionText",
+			"webOTP",
+			"webShareContainingFiles",
+			"webShareNoFiles",
+			"notificationTriggers"
 		],
 		"graphic": {
 			"bgcolor": "#97b5b9",

--- a/config/reports.json
+++ b/config/reports.json
@@ -8,7 +8,8 @@
 		"accessibility",
 		"search-engine-optimization",
 		"page-weight",
-		"chrome-ux-report"
+		"chrome-ux-report",
+		"project-fugu"
 	],
 	"_featured": [
 		"state-of-the-web"
@@ -881,6 +882,24 @@
 			"a11yImageAlt",
 			"a11yLabel",
 			"a11yLinkName"
+		],
+		"graphic": {
+			"bgcolor": "#97b5b9",
+			"primary": {
+				"color": "#eee",
+				"icon": "fas fa-users"
+			},
+			"secondary": {
+				"color": "rgba(255, 255, 255, 0.3)",
+				"text": "A11Y"
+			}
+		}
+	},
+	"project-fugu": {
+		"name": "Capabilities",
+		"summary": "The [Capabilities Project](https://web.dev/fugu-status/) (aka. Project Fugu 🐡) is a cross-company effort at Google to make it possible for web apps to do anything native apps can, by exposing the capabilities of native platforms to the web platform, while maintaining user security, privacy, trust, and other core tenets of the web.",
+		"metrics": [
+			"swControlledPages"
 		],
 		"graphic": {
 			"bgcolor": "#97b5b9",

--- a/config/reports.json
+++ b/config/reports.json
@@ -859,6 +859,48 @@
 				]
 			}
 		},
+		"webUSB": {
+			"name": "(🐡 Launched) Web USB",
+			"type": "%",
+			"downIsBad": true,
+			"description": "This metric tracks the percentage of pages that connect to USB devices via the [Web USB API](https://developers.google.com/web/updates/2016/03/access-usb-devices-on-the-web).",
+			"histogram": {
+				"enabled": false
+			},
+			"timeseries": {
+				"fields": [
+					"percent"
+				]
+			}
+		},
+		"webBluetooth": {
+			"name": "(🐡 Launched) Web Bluetooth",
+			"type": "%",
+			"downIsBad": true,
+			"description": "This metric tracks the percentage of pages that connect to Bluetooth devices via the [Web Bluetooth API](https://developers.google.com/web/updates/2015/07/interact-with-ble-devices-on-the-web).",
+			"histogram": {
+				"enabled": false
+			},
+			"timeseries": {
+				"fields": [
+					"percent"
+				]
+			}
+		},
+		"webMIDI": {
+			"name": "(🐡 Launched) Web MIDI",
+			"type": "%",
+			"downIsBad": true,
+			"description": "This metric tracks the percentage of pages that connect to MIDI devices via the [Web MIDI API](https://developers.google.com/web/shows/google-io/2014/making-music-with-the-web-platform).",
+			"histogram": {
+				"enabled": false
+			},
+			"timeseries": {
+				"fields": [
+					"percent"
+				]
+			}
+		},
 		"webShareContainingFiles": {
 			"name": "(🐡 Launched) Web Share (Containing Files)",
 			"type": "%",
@@ -888,7 +930,7 @@
 			}
 		},
 		"notificationTriggers": {
-			"name": "(🚩 Behind flag) Notification Triggers",
+			"name": "(🧪 Origin trial) Notification Triggers",
 			"type": "%",
 			"downIsBad": true,
 			"description": "This metric tracks the percentage of pages that use scheduled notifications via the [Notification Triggers API](https://web.dev/notification-triggers/).",
@@ -902,7 +944,7 @@
 			}
 		},
 		"webNFCRead": {
-			"name": "(🧪 Origin trial) Web NFC",
+			"name": "(🧪 Origin trial) Web NFC (Read)",
 			"type": "%",
 			"downIsBad": true,
 			"description": "This metric tracks the percentage of pages that *read* NFC tags via the [Web NFC API](https://web.dev/nfc/).",
@@ -916,7 +958,7 @@
 			}
 		},
 		"webNFCWrite": {
-			"name": "(🧪 Origin trial) Web NFC",
+			"name": "(🧪 Origin trial) Web NFC (Write)",
 			"type": "%",
 			"downIsBad": true,
 			"description": "This metric tracks the percentage of pages that *write* NFC tags via the [Web NFC API](https://web.dev/nfc/).",
@@ -934,6 +976,104 @@
 			"type": "%",
 			"downIsBad": true,
 			"description": "This metric tracks the percentage of pages that acquire a screen wake lock via the [Screen Wake Lock API](https://web.dev/wakelock/).",
+			"histogram": {
+				"enabled": false
+			},
+			"timeseries": {
+				"fields": [
+					"percent"
+				]
+			}
+		},
+		"webSerial": {
+			"name": "(🧪 Origin trial) Web Serial",
+			"type": "%",
+			"downIsBad": true,
+			"description": "This metric tracks the percentage of pages that request a serial port via the [Web Serial API](https://wicg.github.io/serial/).",
+			"histogram": {
+				"enabled": false
+			},
+			"timeseries": {
+				"fields": [
+					"percent"
+				]
+			}
+		},
+		"nativeFileSystem": {
+			"name": "(🧪 Origin trial) Native File System",
+			"type": "%",
+			"downIsBad": true,
+			"description": "This metric tracks the percentage of pages that access files via the [Native File System API](https://web.dev/native-file-system/).",
+			"histogram": {
+				"enabled": false
+			},
+			"timeseries": {
+				"fields": [
+					"percent"
+				]
+			}
+		},
+		"contentIndex": {
+			"name": "(🧪 Origin trial) Content Indexing",
+			"type": "%",
+			"downIsBad": true,
+			"description": "This metric tracks the percentage of pages that add content to the content index via the [Content Indexing API](https://web.dev/content-indexing-api/).",
+			"histogram": {
+				"enabled": false
+			},
+			"timeseries": {
+				"fields": [
+					"percent"
+				]
+			}
+		},
+		"quicTransport": {
+			"name": "(🧪 Origin trial) QuicTransport",
+			"type": "%",
+			"downIsBad": true,
+			"description": "This metric tracks the percentage of pages that add transmit messages via the [QuicTransport API](https://web.dev/quictransport/).",
+			"histogram": {
+				"enabled": false
+			},
+			"timeseries": {
+				"fields": [
+					"percent"
+				]
+			}
+		},
+		"textFragment": {
+			"name": "(🐡 Launched) Text Fragment",
+			"type": "%",
+			"downIsBad": true,
+			"description": "This metric tracks the percentage of pages that load with a matched [Text Fragment URL](https://web.dev/text-fragments/).",
+			"histogram": {
+				"enabled": false
+			},
+			"timeseries": {
+				"fields": [
+					"percent"
+				]
+			}
+		},
+		"idleDetection": {
+			"name": "(🧪 Origin trial) Idle Detection",
+			"type": "%",
+			"downIsBad": true,
+			"description": "This metric tracks the percentage of pages that detect when the user is idle via the [Idle Detection API](https://web.dev/idle-detection/).",
+			"histogram": {
+				"enabled": false
+			},
+			"timeseries": {
+				"fields": [
+					"percent"
+				]
+			}
+		},
+		"webSocketStream": {
+			"name": "(🧪 Origin trial) WebSocketStream",
+			"type": "%",
+			"downIsBad": true,
+			"description": "This metric tracks the percentage of pages that transmit messages via the [WebSocketStream API](https://web.dev/websocketstream/).",
 			"histogram": {
 				"enabled": false
 			},
@@ -1160,15 +1300,25 @@
 			"periodicBackgroundSyncRegister",
 			"periodicBackgroundSync",
 			"shapeDetectionBarcode",
-			"shapeDetectionFace",
-			"shapeDetectionText",
 			"webOTP",
+			"webUSB",
+			"webBluetooth",
+			"webMIDI",
+			"screenWakeLock",
+			"textFragment",
 			"webShareContainingFiles",
 			"webShareNoFiles",
 			"notificationTriggers",
 			"webNFCRead",
 			"webNFCWrite",
-			"screenWakeLock"
+			"webSerial",
+			"nativeFileSystem",
+			"contentIndex",
+			"quicTransport",
+			"idleDetection",
+			"webSocketStream",
+			"shapeDetectionFace",
+			"shapeDetectionText"
 		],
 		"graphic": {
 			"bgcolor": "#97b5b9",

--- a/config/reports.json
+++ b/config/reports.json
@@ -602,7 +602,7 @@
 			"name": "Service Worker Controlled Pages",
 			"type": "%",
 			"downIsBad": true,
-			"description": "This metric tracks the percentage of pages that have triggered the ```ServiceWorkerControlledPage``` [use counter](https://cs.chromium.org/chromium/src/third_party/blink/public/platform/web_feature.mojom) that fires whenever a page is controlled by a service worker.",
+			"description": "This metric tracks the percentage of pages that have triggered the ```ServiceWorkerControlledPage``` [use counter](https://source.chromium.org/chromium/chromium/src/+/master:third_party/blink/public/mojom/web_feature/web_feature.mojom) that fires whenever a page is controlled by a service worker.",
 			"histogram": {
 				"enabled": false
 			},
@@ -682,6 +682,90 @@
 			"type": "%",
 			"downIsBad": true,
 			"description": "The percent of pages that pass the [Lighthouse audit](https://dequeuniversity.com/rules/axe/2.2/link-name) that checks if all links have discernable text.",
+			"histogram": {
+				"enabled": false
+			},
+			"timeseries": {
+				"fields": [
+					"percent"
+				]
+			}
+		},
+		"asyncClipboardRead": {
+			"name": "Async Clipboard Read",
+			"type": "%",
+			"downIsBad": true,
+			"description": "This metric tracks the percentage of pages that *read* data from the system clipboard via the [Async Clipboard API](https://web.dev/image-support-for-async-clipboard/).",
+			"histogram": {
+				"enabled": false
+			},
+			"timeseries": {
+				"fields": [
+					"percent"
+				]
+			}
+		},
+		"asyncClipboardWrite": {
+			"name": "Async Clipboard Write",
+			"type": "%",
+			"downIsBad": true,
+			"description": "This metric tracks the percentage of pages that *write* data to the system clipboard via the [Async Clipboard API](https://web.dev/image-support-for-async-clipboard/).",
+			"histogram": {
+				"enabled": false
+			},
+			"timeseries": {
+				"fields": [
+					"percent"
+				]
+			}
+		},
+		"badgeSet": {
+			"name": "Badge Set",
+			"type": "%",
+			"downIsBad": true,
+			"description": "This metric tracks the percentage of pages that *set* a badge via the [Badging API](https://web.dev/badging-api/).",
+			"histogram": {
+				"enabled": false
+			},
+			"timeseries": {
+				"fields": [
+					"percent"
+				]
+			}
+		},
+		"badgeClear": {
+			"name": "Badge Clear",
+			"type": "%",
+			"downIsBad": true,
+			"description": "This metric tracks the percentage of pages that *clear* a badge via the [Badging API](https://web.dev/badging-api/).",
+			"histogram": {
+				"enabled": false
+			},
+			"timeseries": {
+				"fields": [
+					"percent"
+				]
+			}
+		},
+		"contactPicker": {
+			"name": "Contact Picker",
+			"type": "%",
+			"downIsBad": true,
+			"description": "This metric tracks the percentage of pages that access contacts via the [Contact Picker API](https://web.dev/contact-picker/).",
+			"histogram": {
+				"enabled": false
+			},
+			"timeseries": {
+				"fields": [
+					"percent"
+				]
+			}
+		},
+		"getInstalledRelatedApps": {
+			"name": "Get Installed Related Apps",
+			"type": "%",
+			"downIsBad": true,
+			"description": "This metric tracks the percentage of pages that get the installed related apps via the [Get Installed Related Apps API](https://web.dev/get-installed-related-apps/).",
 			"histogram": {
 				"enabled": false
 			},
@@ -897,19 +981,24 @@
 	},
 	"project-fugu": {
 		"name": "Capabilities",
-		"summary": "The [Capabilities Project](https://web.dev/fugu-status/) (aka. Project Fugu 🐡) is a cross-company effort at Google to make it possible for web apps to do anything native apps can, by exposing the capabilities of native platforms to the web platform, while maintaining user security, privacy, trust, and other core tenets of the web.",
+		"summary": "The [Capabilities Project](https://web.dev/fugu-status/) (aka. Project Fugu&nbsp;🐡) is a cross-company effort at Google to make it possible for web apps to do anything native apps can, by exposing the capabilities of native platforms to the web platform, while maintaining user security, privacy, trust, and other core tenets of the web.",
 		"metrics": [
-			"swControlledPages"
+			"asyncClipboardRead",
+			"asyncClipboardWrite",
+			"badgeSet",
+			"badgeClear",
+			"contactPicker",
+			"getInstalledRelatedApps"
 		],
 		"graphic": {
 			"bgcolor": "#97b5b9",
 			"primary": {
 				"color": "#eee",
-				"icon": "fas fa-users"
+				"text": "🐡"
 			},
 			"secondary": {
 				"color": "rgba(255, 255, 255, 0.3)",
-				"text": "A11Y"
+				"text": "Fugu"
 			}
 		}
 	}

--- a/config/reports.json
+++ b/config/reports.json
@@ -817,6 +817,34 @@
 				]
 			}
 		},
+		"storageEstimate": {
+			"name": "(🐡 Launched) Storage Estimation",
+			"type": "%",
+			"downIsBad": true,
+			"description": "This metric tracks the percentage of pages that estimate available storage via the [Shape Detection API](https://web.dev/shape-detection/).",
+			"histogram": {
+				"enabled": false
+			},
+			"timeseries": {
+				"fields": [
+					"percent"
+				]
+			}
+		},
+		"storagePersist": {
+			"name": "(🐡 Launched) Persistent Storage",
+			"type": "%",
+			"downIsBad": true,
+			"description": "This metric tracks the percentage of pages that ask for their data to be stored in persisted storage via the [Storage API](https://web.dev/persistent-storage/).",
+			"histogram": {
+				"enabled": false
+			},
+			"timeseries": {
+				"fields": [
+					"percent"
+				]
+			}
+		},
 		"shapeDetectionFace": {
 			"name": "(🚩 Behind flag) Shape Detection (Face)",
 			"type": "%",
@@ -1300,6 +1328,8 @@
 			"periodicBackgroundSyncRegister",
 			"periodicBackgroundSync",
 			"shapeDetectionBarcode",
+			"storageEstimate",
+			"storagePersist",
 			"webOTP",
 			"webUSB",
 			"webBluetooth",


### PR DESCRIPTION
This PR adds a new top-level report for Project Fugu APIs. It is sorted by the level of maturity of the APIs, starting from (🐡 Launched), over to (🧪 Origin trial), and ending with (🚩 Behind flag).

Some of the reports show no data, since the number of pages that implement these APIs currently is still low. I round to 5 digits in the queries, which, if my math is right and assuming the current size of 5,350,650 URLs of the mobile archive, that there must be at least 0.00001 * 5,350,650 ≈ 54 pages using an API in order for the report to show data.

Please review this jointly with https://github.com/HTTPArchive/bigquery/pull/84.