### PR TITLE
Move Virtual Env folder inline with Web Almanac

### DIFF
--- a/.gcloudignore
+++ b/.gcloudignore
@@ -19,4 +19,5 @@ __pycache__/
 /setup.cfg
 
 env/
+.venv/
 node_modules/

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .idea/
 env/
+.venv/
 node_modules/
 static/js
 *.log

--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ sudo pip install virtualenv
 2. Create an isolated Python environment, and install dependencies:
 
 ```
-virtualenv --python python3 env
-source env/bin/activate
+virtualenv --python python3 .venv
+source .venv/bin/activate
 pip install -r requirements.txt
 ```
 


### PR DESCRIPTION
This moves the virtualenv folder from `env` to `.venv` so that linting tools (such as the GitHub super linter) will ignore them.

This is inline with what the Web Almanac uses.

You can continue to use env if you want.