### PR TITLE
Add test script for report data

### DIFF
--- a/.github/workflows/monthly-report-checks.yml
+++ b/.github/workflows/monthly-report-checks.yml
@@ -40,10 +40,12 @@ jobs:
          REPORT_DATE: ${{ github.event.inputs.REPORT_DATE }}
       run: ./tools/scripts/test_reports.sh
       continue-on-error: true
-    -name: Open Pull Request
-      if: ${{ env.REPORT_FAILS > 0 }}
+    - name: Open Pull Request
+      if: env.REPORT_FAILS > 0
       uses: alialaa/issue-action@v1.0.0
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
         title: This months reports have failed to run
-        body: See log in [GitHub Actions](https://github.com/HTTPArchive/httparchive.org/actions/workflows/monthly-report-checks.yml)
+        body: >
+          See log in [GitHub Actions](https://github.com/HTTPArchive/
+          httparchive.org/actions/workflows/monthly-report-checks.yml)

--- a/.github/workflows/monthly-report-checks.yml
+++ b/.github/workflows/monthly-report-checks.yml
@@ -1,0 +1,34 @@
+######################################
+## Custom HTTP Archive GitHub action ##
+######################################
+#
+# On the 28th of the month it checks all the reports exist for the website.
+# The 28th was choosen so it runs every month (inc February)
+#
+# The crawl should be finished by then but, if not, the reports will not
+# be automatically created when it slips into the new month and will need to manually be
+# created.
+#
+name: Monthly Report Checks
+on:
+  schedule:
+    #        ┌───────────── minute (0 - 59)
+    #        │ ┌───────────── hour (0 - 23)
+    #        │ │ ┌───────────── day of the month (1 - 31)
+    #        │ │ │ ┌───────────── month (1 - 12 or JAN-DEC)
+    #        │ │ │ │ ┌───────────── day of the week (0 - 6 or SUN-SAT)
+    #        │ │ │ │ │
+    #        │ │ │ │ │
+    #        │ │ │ │ │
+    #        * * * * *
+    - cron: '00 09 28 * *'
+  workflow_dispatch:
+jobs:
+  checks:
+    runs-on: ubuntu-20.04
+    if: github.repository == 'HTTPArchive/httparchive.org'
+    steps:
+    - name: Checkout branch
+      uses: actions/checkout@v2.3.4
+    - name: Run the website
+      run: ./tools/scripts/test_reports.sh

--- a/.github/workflows/monthly-report-checks.yml
+++ b/.github/workflows/monthly-report-checks.yml
@@ -37,11 +37,11 @@ jobs:
       uses: actions/checkout@v2.3.4
     - name: Run the website
       env:
-         REPORT_DATE: github.event.inputs.REPORT_DATE
+         REPORT_DATE: ${{ github.event.inputs.REPORT_DATE }}
       run: ./tools/scripts/test_reports.sh
       continue-on-error: true
     -name: Open Pull Request
-      if: ${{ github.env.REPORT_FAILS > 0 }}
+      if: ${{ env.REPORT_FAILS > 0 }}
       uses: alialaa/issue-action@v1.0.0
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/monthly-report-checks.yml
+++ b/.github/workflows/monthly-report-checks.yml
@@ -23,6 +23,11 @@ on:
     #        * * * * *
     - cron: '00 09 28 * *'
   workflow_dispatch:
+    inputs:
+      REPORT_DATE:
+        description: "Date in YYYY_MM_DD format (Optional)"
+        required: false
+        default: 'LATEST'
 jobs:
   checks:
     runs-on: ubuntu-20.04
@@ -31,4 +36,14 @@ jobs:
     - name: Checkout branch
       uses: actions/checkout@v2.3.4
     - name: Run the website
+      env:
+         REPORT_DATE: github.event.inputs.REPORT_DATE
       run: ./tools/scripts/test_reports.sh
+      continue-on-error: true
+    -name: Open Pull Request
+      if: github.env.REPORT_FAILS > 0
+      uses: alialaa/issue-action@v1.0.0
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        title: This months reports have failed to run
+        body: See log in [GitHub Actions](https://github.com/HTTPArchive/httparchive.org/actions/workflows/monthly-report-checks.yml)

--- a/.github/workflows/monthly-report-checks.yml
+++ b/.github/workflows/monthly-report-checks.yml
@@ -41,7 +41,7 @@ jobs:
       run: ./tools/scripts/test_reports.sh
       continue-on-error: true
     -name: Open Pull Request
-      if: github.env.REPORT_FAILS > 0
+      if: ${{ github.env.REPORT_FAILS > 0 }}
       uses: alialaa/issue-action@v1.0.0
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/production-checks.yml
+++ b/.github/workflows/production-checks.yml
@@ -1,5 +1,5 @@
 ######################################
-## Custom Web Almanac GitHub action ##
+## Custom Http Archive GitHub action ##
 ######################################
 #
 # Run checks against the production website
@@ -21,7 +21,7 @@ on:
 jobs:
   checks:
     runs-on: ubuntu-20.04
-    if: github.repository == 'HTTPArchive/almanac.httparchive.org'
+    if: github.repository == 'HTTPArchive/httparchive.org'
     steps:
     - name: Checkout branch
       uses: actions/checkout@v2.3.4

--- a/tools/scripts/test_reports.sh
+++ b/tools/scripts/test_reports.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-if [[ "${REPORT_DATE}" -eq "" || "${REPORT_DATE}" -eq "LATEST" ]]
+if [[ "${REPORT_DATE}" == "" || "${REPORT_DATE}" == "LATEST" ]]
 then
     REPORT_DATE=$(date +%Y_%m_01)
 fi
@@ -12,6 +12,8 @@ https://cdn.httparchive.org/reports/${REPORT_DATE}/bootupJs.json
 https://cdn.httparchive.org/reports/${REPORT_DATE}/vulnJs.json
 https://cdn.httparchive.org/reports/drupal/${REPORT_DATE}/bootupJs.json
 https://cdn.httparchive.org/reports/drupal/${REPORT_DATE}/vulnJs.json
+https://cdn.httparchive.org/reports/wordpress/${REPORT_DATE}/bootupJs.json
+https://cdn.httparchive.org/reports/wordpress/${REPORT_DATE}/vulnJs.json
 END
 )
 
@@ -22,6 +24,8 @@ https://cdn.httparchive.org/reports/numUrls.json
 https://cdn.httparchive.org/reports/a11yButtonName.json
 https://cdn.httparchive.org/reports/drupal/numUrls.json
 https://cdn.httparchive.org/reports/drupal/a11yButtonName.json
+https://cdn.httparchive.org/reports/wordpress/numUrls.json
+https://cdn.httparchive.org/reports/wordpress/a11yButtonName.json
 END
 )
 
@@ -30,7 +34,7 @@ echo "Starting testing"
 for TEST_URL in ${REPORT_MONTHLY_URLS}
 do
     STATUS_CODE=$(curl  -s -o /dev/null -w "%{http_code}" "${TEST_URL}")
-    if [[ "${STATUS_CODE}" -eq "200" ]]
+    if [[ "${STATUS_CODE}" == "200" ]]
     then
         echo "200 Status code found for ${TEST_URL}"
     else
@@ -51,7 +55,10 @@ do
 done
 
 # Export the number of fails to GitHub env
-echo "REPORT_FAILS=${FAIL}" >> "$GITHUB_ENV"
+if [[ "$GITHUB_ENV" ]]
+then
+    echo "REPORT_FAILS=${FAIL}" >> "$GITHUB_ENV"
+fi
 
 if [[ ${FAIL} -gt 0 ]]
 then

--- a/tools/scripts/test_reports.sh
+++ b/tools/scripts/test_reports.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+
+THIS_MONTH=$(date +%Y_%m_01)
+FAIL=0
+
+# These URLs are tested for 200 status
+REPORT_MONTHLY_URLS=$(cat <<-END
+https://cdn.httparchive.org/reports/${THIS_MONTH}/bootupJs.json
+https://cdn.httparchive.org/reports/${THIS_MONTH}/vulnJs.json
+https://cdn.httparchive.org/reports/drupal/${THIS_MONTH}/bootupJs.json
+https://cdn.httparchive.org/reports/drupal/${THIS_MONTH}/vulnJs.json
+END
+)
+
+
+# These URLs are tested if the date exists in the returned body
+TIMESERIES_URLS=$(cat <<-END
+https://cdn.httparchive.org/reports/numUrls.json
+https://cdn.httparchive.org/reports/a11yButtonName.json
+https://cdn.httparchive.org/reports/drupal/numUrls.json
+https://cdn.httparchive.org/reports/drupal/a11yButtonName.json
+END
+)
+
+echo "Starting testing"
+
+for TEST_URL in ${REPORT_MONTHLY_URLS}
+do
+    STATUS_CODE=$(curl  -s -o /dev/null -w "%{http_code}" "${TEST_URL}")
+    if [[ "${STATUS_CODE}" -eq "200" ]]; then
+        echo "200 Status code found for ${TEST_URL}"
+    else
+        echo "Incorrect Status code ${STATUS_CODE} found for ${TEST_URL}"
+        FAIL=$((FAIL+1))
+    fi
+done
+
+for TEST_URL in ${TIMESERIES_URLS}
+do
+    if [[ $(curl -s "${TEST_URL}" | grep "${THIS_MONTH}") ]]; then
+        echo "${THIS_MONTH} found in body for ${TEST_URL}"
+    else
+        echo "${THIS_MONTH} not found in body for ${TEST_URL}"
+        FAIL=$((FAIL+1))
+    fi
+done
+
+if [[ ${FAIL} > 0 ]]; then
+    echo "${FAIL} test(s) failed. Exiting 1"
+    exit 1
+fi
+
+echo "All tests passed"
+exit 0

--- a/tools/scripts/test_reports.sh
+++ b/tools/scripts/test_reports.sh
@@ -27,7 +27,8 @@ echo "Starting testing"
 for TEST_URL in ${REPORT_MONTHLY_URLS}
 do
     STATUS_CODE=$(curl  -s -o /dev/null -w "%{http_code}" "${TEST_URL}")
-    if [[ "${STATUS_CODE}" -eq "200" ]]; then
+    if [[ "${STATUS_CODE}" -eq "200" ]]
+    then
         echo "200 Status code found for ${TEST_URL}"
     else
         echo "Incorrect Status code ${STATUS_CODE} found for ${TEST_URL}"
@@ -37,7 +38,8 @@ done
 
 for TEST_URL in ${TIMESERIES_URLS}
 do
-    if [[ $(curl -s "${TEST_URL}" | grep "${THIS_MONTH}") ]]; then
+    if curl -s "${TEST_URL}" | grep -q "${THIS_MONTH}"
+    then
         echo "${THIS_MONTH} found in body for ${TEST_URL}"
     else
         echo "${THIS_MONTH} not found in body for ${TEST_URL}"
@@ -45,7 +47,8 @@ do
     fi
 done
 
-if [[ ${FAIL} > 0 ]]; then
+if [[ ${FAIL} -gt 0 ]]
+then
     echo "${FAIL} test(s) failed. Exiting 1"
     exit 1
 fi

--- a/tools/scripts/test_reports.sh
+++ b/tools/scripts/test_reports.sh
@@ -1,14 +1,17 @@
 #!/bin/bash
 
-THIS_MONTH=$(date +%Y_%m_01)
+if [[ "${REPORT_DATE}" -eq "" || "${REPORT_DATE}" -eq "LATEST" ]]
+then
+    REPORT_DATE=$(date +%Y_%m_01)
+fi
 FAIL=0
 
 # These URLs are tested for 200 status
 REPORT_MONTHLY_URLS=$(cat <<-END
-https://cdn.httparchive.org/reports/${THIS_MONTH}/bootupJs.json
-https://cdn.httparchive.org/reports/${THIS_MONTH}/vulnJs.json
-https://cdn.httparchive.org/reports/drupal/${THIS_MONTH}/bootupJs.json
-https://cdn.httparchive.org/reports/drupal/${THIS_MONTH}/vulnJs.json
+https://cdn.httparchive.org/reports/${REPORT_DATE}/bootupJs.json
+https://cdn.httparchive.org/reports/${REPORT_DATE}/vulnJs.json
+https://cdn.httparchive.org/reports/drupal/${REPORT_DATE}/bootupJs.json
+https://cdn.httparchive.org/reports/drupal/${REPORT_DATE}/vulnJs.json
 END
 )
 
@@ -38,14 +41,17 @@ done
 
 for TEST_URL in ${TIMESERIES_URLS}
 do
-    if curl -s "${TEST_URL}" | grep -q "${THIS_MONTH}"
+    if curl -s "${TEST_URL}" | grep -q "${REPORT_DATE}"
     then
-        echo "${THIS_MONTH} found in body for ${TEST_URL}"
+        echo "${REPORT_DATE} found in body for ${TEST_URL}"
     else
-        echo "${THIS_MONTH} not found in body for ${TEST_URL}"
+        echo "${REPORT_DATE} not found in body for ${TEST_URL}"
         FAIL=$((FAIL+1))
     fi
 done
+
+# Export the number of fails to GitHub env
+echo "REPORT_FAILS=${FAIL}" >> "$GITHUB_ENV"
 
 if [[ ${FAIL} -gt 0 ]]
 then

--- a/tools/scripts/test_reports.sh
+++ b/tools/scripts/test_reports.sh
@@ -6,24 +6,30 @@ then
 fi
 FAIL=0
 
-# These URLs are tested for 200 status
+# These dated report URLs are tested for 200 status
+# We test the first and last report for each lens
 REPORT_MONTHLY_URLS=$(cat <<-END
 https://cdn.httparchive.org/reports/${REPORT_DATE}/bootupJs.json
 https://cdn.httparchive.org/reports/${REPORT_DATE}/vulnJs.json
 https://cdn.httparchive.org/reports/drupal/${REPORT_DATE}/bootupJs.json
 https://cdn.httparchive.org/reports/drupal/${REPORT_DATE}/vulnJs.json
+https://cdn.httparchive.org/reports/magento/${REPORT_DATE}/bootupJs.json
+https://cdn.httparchive.org/reports/magento/${REPORT_DATE}/vulnJs.json
 https://cdn.httparchive.org/reports/wordpress/${REPORT_DATE}/bootupJs.json
 https://cdn.httparchive.org/reports/wordpress/${REPORT_DATE}/vulnJs.json
 END
 )
 
 
-# These URLs are tested if the date exists in the returned body
+# These timeseries URLs are tested if the date exists in the returned body
+# We test the first and last report for each lens
 TIMESERIES_URLS=$(cat <<-END
 https://cdn.httparchive.org/reports/numUrls.json
 https://cdn.httparchive.org/reports/a11yButtonName.json
 https://cdn.httparchive.org/reports/drupal/numUrls.json
 https://cdn.httparchive.org/reports/drupal/a11yButtonName.json
+https://cdn.httparchive.org/reports/magento/numUrls.json
+https://cdn.httparchive.org/reports/magento/a11yButtonName.json
 https://cdn.httparchive.org/reports/wordpress/numUrls.json
 https://cdn.httparchive.org/reports/wordpress/a11yButtonName.json
 END


### PR DESCRIPTION
Adds a script and a GitHub action to test the reports exist for this month on the 28th of the month.

Opens an issue if they are not.

Hopefully avoids issues like #283 where we don't notice for a month or two.

Quite like having this completely outside of Google Cloud Platform/Storage as an independent test.