### PR TITLE
Fix annotations

### DIFF
--- a/config/last_updated.json
+++ b/config/last_updated.json
@@ -11,8 +11,8 @@
   },
   "/static/css/report.css": {
     "date_published": "2018-05-08T00:00:00.000Z",
-    "date_modified": "2021-05-19T00:00:00.000Z",
-    "hash": "46c7c17f5035a5209af3ddc5a2f1d4ea"
+    "date_modified": "2021-04-26T00:00:00.000Z",
+    "hash": "00da69106b249c042a0657d78ffe4c11"
   },
   "/static/css/reports.css": {
     "date_published": "2018-05-08T00:00:00.000Z",
@@ -66,8 +66,8 @@
   },
   "/static/js/timeseries.js": {
     "date_published": "2018-05-08T00:00:00.000Z",
-    "date_modified": "2021-04-26T00:00:00.000Z",
-    "hash": "bcdeb2a4bb572b4b8eeab12169de0a0f"
+    "date_modified": "2021-05-19T00:00:00.000Z",
+    "hash": "ec2cd88069d99759394a24b8259b04c9"
   },
   "about.html": {
     "date_published": "2018-05-08T00:00:00.000Z",

--- a/config/last_updated.json
+++ b/config/last_updated.json
@@ -11,8 +11,8 @@
   },
   "/static/css/report.css": {
     "date_published": "2018-05-08T00:00:00.000Z",
-    "date_modified": "2021-04-26T00:00:00.000Z",
-    "hash": "00da69106b249c042a0657d78ffe4c11"
+    "date_modified": "2021-05-19T00:00:00.000Z",
+    "hash": "46c7c17f5035a5209af3ddc5a2f1d4ea"
   },
   "/static/css/reports.css": {
     "date_published": "2018-05-08T00:00:00.000Z",
@@ -24,6 +24,11 @@
     "date_modified": "2021-04-26T00:00:00.000Z",
     "hash": "c5dfe3a91d8e78b171cd5c3059ab55d7"
   },
+  "/static/js/exporting.js": {
+    "date_published": "2021-05-19T00:00:00.000Z",
+    "date_modified": "2021-05-19T00:00:00.000Z",
+    "hash": "e96a3b2f9f14fddd5d94fc6212c9a373"
+  },
   "/static/js/faq.js": {
     "date_published": "2018-05-08T00:00:00.000Z",
     "date_modified": "2021-04-24T00:00:00.000Z",
@@ -31,13 +36,13 @@
   },
   "/static/js/highcharts-more.js": {
     "date_published": "2021-04-26T00:00:00.000Z",
-    "date_modified": "2021-04-26T00:00:00.000Z",
-    "hash": "679aad6f3635cab282bf729bad76d9f4"
+    "date_modified": "2021-05-19T00:00:00.000Z",
+    "hash": "c0a7c04eeba32ef638f18006d047baaa"
   },
   "/static/js/highstock.js": {
     "date_published": "2021-04-26T00:00:00.000Z",
-    "date_modified": "2021-04-26T00:00:00.000Z",
-    "hash": "0f7415bff9b44ceb9b082b777bfd493a"
+    "date_modified": "2021-05-19T00:00:00.000Z",
+    "hash": "9e37379df58a4a4dd15e0cecb8912fec"
   },
   "/static/js/histogram.js": {
     "date_published": "2018-05-08T00:00:00.000Z",

--- a/src/js/timeseries.js
+++ b/src/js/timeseries.js
@@ -456,4 +456,5 @@ const toRow = (o, i, n, cols) => {
 };
 
 // Export directly to global scope for use by Jinja template.
+
 window.timeseries = timeseries;

--- a/src/js/timeseries.js
+++ b/src/js/timeseries.js
@@ -266,6 +266,7 @@ const getFlagSeries = () => loadChangelog().then(data => {
       x: change.date,
       title: String.fromCharCode(65 + (i % 26))
     })),
+    clip: false,
     color: '#90b1b6',
     y: 25,
     showInLegend: false

--- a/src/js/timeseries.js
+++ b/src/js/timeseries.js
@@ -456,5 +456,4 @@ const toRow = (o, i, n, cols) => {
 };
 
 // Export directly to global scope for use by Jinja template.
-
 window.timeseries = timeseries;

--- a/static/css/report.css
+++ b/static/css/report.css
@@ -200,10 +200,6 @@ th {
   color: red;
 }
 
-.highcharts-markers {
-  clip-path: none !important;
-}
-
 #report-metrics.grid-view .report-metrics-inner-wrapper {
   display: grid;
   grid-gap: 40px;

--- a/static/css/report.css
+++ b/static/css/report.css
@@ -200,6 +200,10 @@ th {
   color: red;
 }
 
+.highcharts-markers {
+  clip-path: none !important;
+}
+
 #report-metrics.grid-view .report-metrics-inner-wrapper {
   display: grid;
   grid-gap: 40px;

--- a/templates/report/report.html
+++ b/templates/report/report.html
@@ -156,7 +156,7 @@
 {% block scripts %}
   {{ super() }}
   <script src="{{ get_versioned_filename('/static/js/highstock.js') }}"></script>
-  <script src="https://cdn.httparchive.org/reports/exporting.js"></script>
+  <script src="{{ get_versioned_filename('/static/js/exporting.js') }}"></script>
   <script src="{{ get_versioned_filename('/static/js/report.js') }}"></script>
   <script nonce="{{ csp_nonce() }}">
     var report = {{ report|tojson }};

--- a/tools/generate/generate_js.js
+++ b/tools/generate/generate_js.js
@@ -12,6 +12,11 @@ const generate_js = async () => {
     './node_modules/highcharts/highstock.js',
     './static/js/highstock.js',
   );
+  console.log(` Copying exporting.js`);
+  fs.copy(
+    './node_modules/highcharts/modules/exporting.js',
+    './static/js/exporting.js',
+  );
 };
 
 module.exports = {


### PR DESCRIPTION
Fixes a couple of bugs noticed recently:

First up - the annotations are not showing up properly:

![Annotations on timeseries charts](https://user-images.githubusercontent.com/10931297/118737579-0321e180-b83d-11eb-9b10-44ca77384860.png)

Looks like a bug introduced in v6.1.4 and I recently upgraded from v6.0.2 all the way to latest (9.1.0).
I can't actually see what's wrong here, but it's definitely to do with the clip path it adds. Overriding it solves the issues. Not the happiest with this fix but spent a long time at it and can't get a better one.

Secondly I noticed we were loading the exporting.js from CDN meaning we were loading the v6.0.2. version still. It appears to work despite the massive version gap but still - should be in sync. This moves it inline with the rest and also means the exports get the chart name rather than a generic chart.png.
