### PR TITLE
Set correct direction of Poor CLS graph

### DIFF
--- a/config/reports.json
+++ b/config/reports.json
@@ -609,7 +609,7 @@
       "name": "Poor Cumulative Layout Shift",
       "type": "%",
       "description": "The percent of \"poor\" CLS experiences, greater than 0.25.",
-      "downIsBad": true,
+      "downIsBad": false,
       "histogram": {
         "enabled": false
       },


### PR DESCRIPTION
Going down is good for "poor" metrics so this should be green not red:

![image](https://user-images.githubusercontent.com/10931297/119659733-5b9d4400-be26-11eb-8ea3-a7a5039680ce.png)
