### PR TITLE
Allow more discourse hostnames to fix CSP error

### DIFF
--- a/csp.py
+++ b/csp.py
@@ -36,7 +36,7 @@ csp = {
         'www.google.com',
         's.g.doubleclick.net',
         'stats.g.doubleclick.net',
-        'sjc3.discourse-cdn.com',
+        '*.discourse-cdn.com',
         'res.cloudinary.com'
     ]
 }


### PR DESCRIPTION
Fixes this:

![image](https://user-images.githubusercontent.com/10931297/120930008-56bc7800-c6e3-11eb-9a69-89c2cd4a8e78.png)

To this:

![image](https://user-images.githubusercontent.com/10931297/120930016-5d4aef80-c6e3-11eb-9a63-ddce01114f83.png)

As spotted by [our weekly Lighthouse run](https://github.com/HTTPArchive/httparchive.org/actions/runs/911906099).