### PR TITLE
Add Passes Core Web Vitals report

### DIFF
--- a/config/reports.json
+++ b/config/reports.json
@@ -524,7 +524,7 @@
     "cruxPassesCWV": {
       "name": "Passes Core Web Vitals",
       "type": "%",
-      "description": "The percentage of origins passing all three [Core Web Vitals](https://web.dev/vitals/#core-web-vitals) (LCP, FID, CLS) with a \"good\" experience.",
+      "description": "The percentage of origins passing all three [Core Web Vitals](https://web.dev/vitals/#core-web-vitals) (LCP, FID, CLS) with a \"good\" experience. Note that if an origin is missing FID data, it's assessed based on the performance of the remaining metrics.",
       "downIsBad": true,
       "histogram": {
         "enabled": false
@@ -538,7 +538,7 @@
     "cruxFastFcp": {
       "name": "Good First Contentful Paint",
       "type": "%",
-      "description": "The percentage of origins with \"good\" FCP experiences, less than or equal to 1 second.",
+      "description": "The percentage of origins with \"good\" FCP experiences, less than or equal to 1.8 seconds.",
       "downIsBad": true,
       "histogram": {
         "enabled": false

--- a/config/reports.json
+++ b/config/reports.json
@@ -521,10 +521,24 @@
         "minDate": "2018_06_01"
       }
     },
+    "cruxPassesCWV": {
+      "name": "Passes Core Web Vitals",
+      "type": "%",
+      "description": "The percentage of origins passing all three Core Web Vitals (LCP, FID, CLS) with a \"good\" experience.",
+      "downIsBad": true,
+      "histogram": {
+        "enabled": false
+      },
+      "timeseries": {
+        "fields": [
+          "percent"
+        ]
+      }
+    },
     "cruxFastFcp": {
       "name": "Good First Contentful Paint",
       "type": "%",
-      "description": "The percent of \"good\" FCP experiences, less than or equal to 1 second.",
+      "description": "The percentage of origins with \"good\" FCP experiences, less than or equal to 1 second.",
       "downIsBad": true,
       "histogram": {
         "enabled": false
@@ -538,7 +552,7 @@
     "cruxFastFp": {
       "name": "Good First Paint",
       "type": "%",
-      "description": "The percent of \"good\" FP experiences, less than or equal to 1 second.",
+      "description": "The percentage of origins with \"good\" FP experiences, less than or equal to 1 second.",
       "downIsBad": true,
       "histogram": {
         "enabled": false
@@ -552,7 +566,7 @@
     "cruxFastDcl": {
       "name": "Good DOM Content Loaded",
       "type": "%",
-      "description": "The percent of \"good\" DCL experiences, less than or equal to 1 second.",
+      "description": "The percentage of origins with \"good\" DCL experiences, less than or equal to 1 second.",
       "downIsBad": true,
       "histogram": {
         "enabled": false
@@ -566,7 +580,7 @@
     "cruxFastOl": {
       "name": "Good Onload",
       "type": "%",
-      "description": "The percent of \"good\" OL experiences, less than or equal to 1 second.",
+      "description": "The percentage of origins with \"good\" OL experiences, less than or equal to 1 second.",
       "downIsBad": true,
       "histogram": {
         "enabled": false
@@ -580,7 +594,7 @@
     "cruxFastFid": {
       "name": "Good First Input Delay",
       "type": "%",
-      "description": "The percent of \"good\" FID experiences, less than or equal to 100 ms. See [FID in CrUX](https://developers.google.com/web/updates/2018/07/first-input-delay-in-crux).",
+      "description": "The percentage of origins with \"good\" FID experiences, less than or equal to 100 ms. See [FID in CrUX](https://developers.google.com/web/updates/2018/07/first-input-delay-in-crux).",
       "downIsBad": true,
       "histogram": {
         "enabled": false
@@ -594,7 +608,7 @@
     "cruxFastLcp": {
       "name": "Good Largest Contentful Paint",
       "type": "%",
-      "description": "The percent of \"good\" LCP experiences, less than or equal to 2.5 seconds.",
+      "description": "The percentage of origins with \"good\" LCP experiences, less than or equal to 2.5 seconds.",
       "downIsBad": true,
       "histogram": {
         "enabled": false
@@ -608,7 +622,7 @@
     "cruxLargeCls": {
       "name": "Poor Cumulative Layout Shift",
       "type": "%",
-      "description": "The percent of \"poor\" CLS experiences, greater than 0.25.",
+      "description": "The percentage of origins with \"poor\" CLS experiences, greater than 0.25.",
       "downIsBad": false,
       "histogram": {
         "enabled": false
@@ -622,7 +636,7 @@
     "cruxSlowFcp": {
       "name": "Poor First Contentful Paint",
       "type": "%",
-      "description": "The percent of \"poor\" FCP experiences, greater than 3 seconds.",
+      "description": "The percentage of origins with \"poor\" FCP experiences, greater than 3 seconds.",
       "histogram": {
         "enabled": false
       },
@@ -635,7 +649,7 @@
     "cruxSlowFid": {
       "name": "Poor First Input Delay",
       "type": "%",
-      "description": "The percent of \"poor\" FID experiences, greater than 250 ms. See [FID in CrUX](https://developers.google.com/web/updates/2018/07/first-input-delay-in-crux).",
+      "description": "The percentage of origins with \"poor\" FID experiences, greater than 250 ms. See [FID in CrUX](https://developers.google.com/web/updates/2018/07/first-input-delay-in-crux).",
       "histogram": {
         "enabled": false
       },
@@ -648,7 +662,7 @@
     "cruxSlowLcp": {
       "name": "Poor Largest Contentful Paint",
       "type": "%",
-      "description": "The percent of \"poor\" LCP experiences, greater than 4.0 seconds.",
+      "description": "The percentage of origins with \"poor\" LCP experiences, greater than 4.0 seconds.",
       "histogram": {
         "enabled": false
       },
@@ -661,7 +675,7 @@
     "cruxSmallCls": {
       "name": "Good Cumulative Layout Shift",
       "type": "%",
-      "description": "The percent of \"good\" CLS experiences, less and or equal to 0.1.",
+      "description": "The percentage of origins with \"good\" CLS experiences, less and or equal to 0.1.",
       "downIsBad": true,
       "histogram": {
         "enabled": false
@@ -1123,6 +1137,7 @@
     "summary": "Loading and interactivity performance as experienced by real-world Chrome users across a diverse set of hardware and network conditions, powered by the [Chrome User Experience Report](https://developers.google.com/web/tools/chrome-user-experience-report/).",
     "image": "/static/img/reports/chrome-user-experience-report.png",
     "metrics": [
+      "cruxPassesCWV",
       "cruxFastFcp",
       "cruxSlowFcp",
       "cruxFastLcp",

--- a/config/reports.json
+++ b/config/reports.json
@@ -524,7 +524,7 @@
     "cruxPassesCWV": {
       "name": "Passes Core Web Vitals",
       "type": "%",
-      "description": "The percentage of origins passing all three Core Web Vitals (LCP, FID, CLS) with a \"good\" experience.",
+      "description": "The percentage of origins passing all three [Core Web Vitals](https://web.dev/vitals/#core-web-vitals) (LCP, FID, CLS) with a \"good\" experience.",
       "downIsBad": true,
       "histogram": {
         "enabled": false

--- a/reports.py
+++ b/reports.py
@@ -105,7 +105,9 @@ def get_latest_date(metric_id):
     global latest_metric_dates
     # Check the cache before hitting GCS.
     latest_date = latest_metric_dates.get(metric_id)
-    if latest_date:
+    # Only return the cached value if it's the latest date
+    # So reports like CrUX which come in later are checked each time
+    if latest_date and latest_date == report_dates[0]:
         return latest_date
     latest_date = date_util.get_latest_date(report_dates, metric_id)
     latest_metric_dates[metric_id] = latest_date

--- a/reports.py
+++ b/reports.py
@@ -15,6 +15,7 @@ MAX_REPORT_STALENESS = 60 * 60 * 3
 
 last_report_update = 0
 latest_metric_dates = {}
+latest_metric_check = {}
 report_dates = []
 reports_json = {}
 
@@ -103,8 +104,8 @@ def get_dates():
 def get_latest_date(metric_id):
     global report_dates
     global latest_metric_dates
+    global latest_metric_check
     global MAX_REPORT_STALENESS
-    global last_report_update
 
     # Check the cache before hitting GCS.
     latest_date = latest_metric_dates.get(metric_id)
@@ -115,12 +116,13 @@ def get_latest_date(metric_id):
             return latest_date
         # If it's not the latest date, but we're withing our staleness time period
         # then also OK to use this
-        if (time() - last_report_update) < MAX_REPORT_STALENESS:
+        if (time() - latest_metric_check[metric_id]) < MAX_REPORT_STALENESS:
             return latest_date
 
     # If not using cached value then get the latest value
     latest_date = date_util.get_latest_date(report_dates, metric_id)
     latest_metric_dates[metric_id] = latest_date
+    latest_metric_check[metric_id] = time()
     return latest_date
 
 

--- a/reports.py
+++ b/reports.py
@@ -114,7 +114,7 @@ def get_latest_date(metric_id):
         # So reports like CrUX which come in later are checked each time
         if latest_date == report_dates[0]:
             return latest_date
-        # If it's not the latest date, but we're withing our staleness time period
+        # If it's not the latest date, but we're within our staleness time period
         # then also OK to use this
         if (time() - latest_metric_check[metric_id]) < MAX_REPORT_STALENESS:
             return latest_date


### PR DESCRIPTION
Adds a new "Passes Core Web Vitals" report following on from the query addition in https://github.com/HTTPArchive/bigquery/pull/107

Looks like this - nice uptick since February!

![Passes Core Web Vitals graph](https://user-images.githubusercontent.com/10931297/121328391-315e8280-c90c-11eb-9b4e-417703120f84.png)

Also changes the description of the other CrUX reports to make it more obvious these are the origin scores.

And also includes a fix so new report dates are found for CrUX reports that come in later in the month.