### PR TITLE
Add HTTP/3 report

### DIFF
--- a/config/reports.json
+++ b/config/reports.json
@@ -289,7 +289,21 @@
     "h2": {
       "name": "HTTP/2 Requests",
       "type": "%",
-      "description": "The percent of all requests in the crawl using HTTP/2.",
+      "description": "The percent of all requests in the crawl using HTTP/2. Note servers supporting HTTP/2 and HTTP/3, may use HTTP/2 initially due to the way the HTTPArchive starts with a fresh Chrome instance each time, but may use HTTP/3 on subsequent requests.",
+      "downIsBad": true,
+      "histogram": {
+        "enabled": false
+      },
+      "timeseries": {
+        "fields": [
+          "percent"
+        ]
+      }
+    },
+    "h3": {
+      "name": "HTTP/3 Support",
+      "type": "%",
+      "description": "The percent of all requests in the crawl which support HTTP/3. Note that, due to the way the HTTPArchive starts with a fresh Chrome instance each time, HTTP/3 will often not be used for initial connections until the browser is aware the server supports HTTP/3, which is why we measure support, rather than actual usage like we do for HTTP/2.",
       "downIsBad": true,
       "histogram": {
         "enabled": false
@@ -1069,6 +1083,7 @@
       "pctVuln",
       "tcp",
       "h2",
+      "h3",
       "vulnJs",
       "fontDisplay"
     ],

--- a/config/reports.json
+++ b/config/reports.json
@@ -289,7 +289,7 @@
     "h2": {
       "name": "HTTP/2 Requests",
       "type": "%",
-      "description": "The percent of all requests in the crawl using HTTP/2. Note servers supporting HTTP/2 and HTTP/3, may use HTTP/2 initially due to the way the HTTPArchive starts with a fresh Chrome instance each time, but may use HTTP/3 on subsequent requests.",
+      "description": "The percent of all requests in the crawl using HTTP/2. Note that servers supporting HTTP/2 and HTTP/3 may use HTTP/2 initially due to the way the HTTP Archive starts with a fresh Chrome instance each time, but may use HTTP/3 on subsequent requests.",
       "downIsBad": true,
       "histogram": {
         "enabled": false
@@ -303,7 +303,7 @@
     "h3": {
       "name": "HTTP/3 Support",
       "type": "%",
-      "description": "The percent of all requests in the crawl which support HTTP/3. Note that, due to the way the HTTPArchive starts with a fresh Chrome instance each time, HTTP/3 will often not be used for initial connections until the browser is aware the server supports HTTP/3, which is why we measure support, rather than actual usage like we do for HTTP/2.",
+      "description": "The percent of all requests in the crawl which support HTTP/3. Note that, due to the way the HTTP Archive starts with a fresh Chrome instance each time, HTTP/3 will often not be used for initial connections until the browser is aware the server supports HTTP/3, which is why we measure support, rather than actual usage like we do for HTTP/2.",
       "downIsBad": true,
       "histogram": {
         "enabled": false


### PR DESCRIPTION
Adds the new HTTP/3 report as created in https://github.com/HTTPArchive/bigquery/pull/111

![HTTP/3 report](https://user-images.githubusercontent.com/10931297/123318667-5f0c1400-d527-11eb-83ec-31a4ef34aa06.png)

I've reached out to some HTTP/3 experts to see if they can explain that dip.

Also added some more explanation to HTTP/2 chart:

![HTTP/3 chart](https://user-images.githubusercontent.com/10931297/123318750-7b0fb580-d527-11eb-897c-6f91027772da.png)
