### PR TITLE
Add rank lenses

### DIFF
--- a/config/reports.json
+++ b/config/reports.json
@@ -23,6 +23,18 @@
     },
     "wordpress": {
       "name": "WordPress"
+    },
+    "top1k": {
+      "name": "Top 1,000"
+    },
+    "top10k": {
+      "name": "Top 10,000"
+    },
+    "top100k": {
+      "name": "Top 100,000"
+    },
+    "top1m": {
+      "name": "Top 1,000,000"
     }
   },
   "_metrics": {


### PR DESCRIPTION
Once https://github.com/HTTPArchive/bigquery/pull/121 lands and we run the last of the lenses we should add to the report. This PR does that:

![Lens drop down](https://user-images.githubusercontent.com/10931297/127525792-c5c4963b-4a2d-436f-ab2c-1a20395d8df2.png)

Question is whether to drop the old lenses or not? I vote yes to drop from GUI (i.e. update this PR to remove them), but leave them running in background for another month in case of push back. Then drop from bigquery repo if no complaints. Thoughts?