### PR TITLE
Allow buttons with large text to overflow

### DIFF
--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -607,7 +607,7 @@ ul.bulleted li ul {
   line-height: 1.5rem;
   text-align: center;
   color: #667a7d;
-  white-space:normal !important;
+  white-space: normal !important;
   word-wrap: break-word;
 }
 

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -604,9 +604,11 @@ ul.bulleted li ul {
   padding: 6px 20px;
   background-color: #fff;
   font-size: 1.3rem;
-  line-height: 1.3rem;
+  line-height: 1.5rem;
   text-align: center;
   color: #667a7d;
+  white-space:normal !important;
+  word-wrap: break-word;
 }
 
 .btn:hover,


### PR DESCRIPTION
Spotted and issue on mobile with some of the buttons on the report page (PWA and CWV Tech Report):

![image](https://user-images.githubusercontent.com/10931297/134061235-7e16f2b3-56c8-48a8-a3e4-38d430bce033.png)
