### PR TITLE
Add name to package lock

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "httparchive.org",
       "version": "0.0.1",
       "license": "Apache-2.0",
       "devDependencies": {


### PR DESCRIPTION
The name gets automatically added on `npm install` so let's commit it to avoid seeing "change" in this file each time.