### PR TITLE
Upgrade node to v16

### DIFF
--- a/.github/workflows/predeploy.yml
+++ b/.github/workflows/predeploy.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Setup Node.js for use with actions
       uses: actions/setup-node@v3
       with:
-        node-version: '15'
+        node-version: '16'
     - name: Set up Python 3.8
       uses: actions/setup-python@v3
       with:

--- a/.github/workflows/test-website.yml
+++ b/.github/workflows/test-website.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Setup Node.js for use with actions
       uses: actions/setup-node@v3
       with:
-        node-version:  '15'
+        node-version:  '16'
     - name: Set up Python 3.8
       uses: actions/setup-python@v3
       with:

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "httparchive.org",
       "version": "0.0.1",
       "license": "Apache-2.0",
       "devDependencies": {


### PR DESCRIPTION
This doesn't need Node 16, but will force to use newer npm which avoids issue for anyone using this locally (I use Node 14 locally but with latest npm).