### PR TITLE
Add changelog about May 2022 response bodies not being available

### DIFF
--- a/src/js/timeseries.js
+++ b/src/js/timeseries.js
@@ -259,6 +259,8 @@ const getFlagSeries = () => loadChangelog().then(data => {
       desc: change.desc
     };
   });
+  // Filter out changes that don't need to be displayed in time series
+  data = data.filter(o => o.displayInTimeSeries !== false);
   return {
     type: 'flags',
     name: 'Changelog',

--- a/static/json/changelog.json
+++ b/static/json/changelog.json
@@ -91,6 +91,12 @@
     },
     {
         "date": 1651363200000,
+        "title": "Response bodies unavailable for May 2022",
+        "desc": "Due to a crawl config error, we don't have response bodies in the May 2022 dataset.",
+        "displayInTimeSeries": false
+    },
+    {
+        "date": 1651363200000,
         "title": "Lighthouse desktop integration",
         "desc": "Lighthouse testing for Desktop crawl added, in addition to Mobile (which was added in 2017)"
     },


### PR DESCRIPTION
Fixes #614 

Note this also adds an optional `displayInTimeSeries` boolean flag that when set to `false` is excluded from the timeseries charts.