### PR TITLE
Redirect legacy to bare domain

### DIFF
--- a/server/__init__.py
+++ b/server/__init__.py
@@ -62,7 +62,11 @@ legacy_util = Legacy(faq_util)
 def redirect_www():
     """Redirect subdomain requests to bare domain."""
     urlparts = urlparse(request.url)
-    if urlparts.netloc == 'www.httparchive.org' or urlparts.netloc == 'beta.httparchive.org' or urlparts.netloc == 'legacy.httparchive.org':
+    if (
+        urlparts.netloc == "www.httparchive.org"
+        or urlparts.netloc == "beta.httparchive.org"
+        or urlparts.netloc == "legacy.httparchive.org"
+    ):
         urlparts_list = list(urlparts)
         urlparts_list[1] = 'httparchive.org'
         return redirect(urlunparse(urlparts_list), code=301)

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -60,9 +60,9 @@ legacy_util = Legacy(faq_util)
 
 @app.before_request
 def redirect_www():
-    """Redirect www and beta requests to bare domain."""
+    """Redirect subdomain requests to bare domain."""
     urlparts = urlparse(request.url)
-    if urlparts.netloc == 'www.httparchive.org' or urlparts.netloc == 'beta.httparchive.org':
+    if urlparts.netloc == 'www.httparchive.org' or urlparts.netloc == 'beta.httparchive.org' or urlparts.netloc == 'legacy.httparchive.org':
         urlparts_list = list(urlparts)
         urlparts_list[1] = 'httparchive.org'
         return redirect(urlunparse(urlparts_list), code=301)

--- a/server/tests/routes_test.py
+++ b/server/tests/routes_test.py
@@ -65,6 +65,10 @@ def test_reports_beta(client):
     assert_route(client, "https://beta.httparchive.org/reports", 301, "https://httparchive.org/reports")
 
 
+def test_reports_legacy(client):
+    assert_route(client, "https://legacy.httparchive.org/reports", 301, "https://httparchive.org/reports")
+
+
 def test_report_state_of_the_web_lens(client):
     response = client.get('/reports/state-of-the-web?lens=top1k')
     assert response.status_code == 200 and \


### PR DESCRIPTION
DNS for the legacy subdomain is set up to direct to GAE. This adds support for redirecting it to the bare domain, similar to www and beta subdomains.