### PR TITLE
Update project name

### DIFF
--- a/docs/gettingstarted_bigquery.md
+++ b/docs/gettingstarted_bigquery.md
@@ -33,7 +33,7 @@ In order to access the HTTP Archive via BigQuery, you'll need a Google account. 
 
 6. In order to add the HTTP Archive tables to your project, click on Add Data ->Star a project by name.
 
-7. Type in `HTTPArchive` and click `STAR`.
+7. Type in `httparchive` (case-sensitive) and click `STAR`.
 
 8. You should now see the HTTP Archive data set pinned:
 


### PR DESCRIPTION
The current instructions don't work when using the given project name and results in a rather cryptic error.

![image](https://user-images.githubusercontent.com/1621608/204888967-ddb5dd28-441e-49ff-b3d4-426bff36788e.png)
![image](https://user-images.githubusercontent.com/1621608/204889005-f8a4b82a-8d6f-49ab-b29a-99acc1f8d191.png)

As shown in https://discuss.httparchive.org/t/bigquery-broken-link/2366/11 (and confirmed in my own set up), the project name must be all lower case.

This PR corrects the instruction as well as emphasizes the importance of the case for the HTTP Archive project data to be added successfully.

