### PR TITLE
Added a changelog entry for the Ubuntu upgrade

### DIFF
--- a/static/json/changelog.json
+++ b/static/json/changelog.json
@@ -104,5 +104,10 @@
         "date": 1654041600000,
         "title": "Mobile network throttling changed from 3G to 4G (faster performance)",
         "desc": "Note: Lighthouse still running at Fast 3G so this only affects the HTTP Archive crawl."
+    },
+    {
+        "date": 1672531200000,
+        "title": "Upgrade agents to Ubuntu 22.04",
+        "desc": "Upgraded the test agents from Ubuntu 18.04 to 22.04."
     }
 ]


### PR DESCRIPTION
The date should map to January 1 2023 0:0:0 since it only takes effect when the new crawl starts.