### PR TITLE
Remove total-byte-weight audit

### DIFF
--- a/.github/lighthouse/lighthouse-config-dev.json
+++ b/.github/lighthouse/lighthouse-config-dev.json
@@ -27,6 +27,7 @@
         "splash-screen": "off",
         "themed-omnibox": "off",
         "third-party-facades": "off",
+        "total-byte-weight": "off",
         "unminified-css": "off",
         "unminified-javascript": "off",
         "unused-css-rules": "off",

--- a/.github/lighthouse/lighthouse-config-prod.json
+++ b/.github/lighthouse/lighthouse-config-prod.json
@@ -27,6 +27,7 @@
         "splash-screen": "off",
         "themed-omnibox": "off",
         "third-party-facades": "off",
+        "total-byte-weight": "off",
         "unminified-css": "off",
         "unminified-javascript": "off",
         "unused-css-rules": "off",


### PR DESCRIPTION
The [CrUX reports](https://httparchive.org/reports/chrome-ux-report) have so much data they now are 300KB each and so cause the `total-byte-weight` Lighthouse audit to fail as the page is 5.4MB (over the 5MB limit). So let's turn that one off.

Obviously not great that the JSONs are that large, and may want to look at lazy loading the charts, but there is a lot of data so let's go for the easy fix for now.