### PR TITLE
Remove a11y bypass audit

### DIFF
--- a/config/reports.json
+++ b/config/reports.json
@@ -840,20 +840,6 @@
         ]
       }
     },
-    "a11yBypass": {
-      "name": "Bypass",
-      "type": "%",
-      "downIsBad": true,
-      "description": "The percent of pages that pass the [Lighthouse bypass audit](https://web.dev/bypass/) that checks if pages provide a way to bypass repeated blocks of content.",
-      "histogram": {
-        "enabled": false
-      },
-      "timeseries": {
-        "fields": [
-          "percent"
-        ]
-      }
-    },
     "a11yColorContrast": {
       "name": "Color Contrast",
       "type": "%",
@@ -1316,7 +1302,6 @@
     "metrics": [
       "a11yScores",
       "a11yButtonName",
-      "a11yBypass",
       "a11yColorContrast",
       "a11yImageAlt",
       "a11yLabel",


### PR DESCRIPTION
In Lighthouse v10 the bypass audit has become informational and so is no longer scored so cannot be graphed:

<img width="1174" alt="image" src="https://user-images.githubusercontent.com/10931297/225715067-8784b1c5-795b-4609-bbb4-98a205ab6fdc.png">

This PR removed it from the site.
Will open a separate one to remove the SQL from running from BigQuery repo.