### PR TITLE
Link directly to queries

### DIFF
--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -59,7 +59,7 @@ export const drawMetricSummary = (options, client, value, isMedian=true, change=
 };
 
 const getQueryUrl = (metric, type) => {
-  const URL_BASE = 'https://cdn.rawgit.com/HTTPArchive/bigquery/master/sql';
+  const URL_BASE = 'https://github.com/HTTPArchive/bigquery/blob/master/sql';
   if (type === 'timeseries') {
     return `${URL_BASE}/timeseries/${metric}.sql`;
   }


### PR DESCRIPTION

<img width="312" alt="image" src="https://user-images.githubusercontent.com/1120896/229329867-a29e2587-1720-411f-89a7-6aedb7515346.png">


In reports, the "Show query" link opens a rawgit URL, which prompts users to download the query, rather than viewing it in their browser. Point directly to the GitHub source instead.