### PR TITLE
LoAF origin trial

### DIFF
--- a/config/last_updated.json
+++ b/config/last_updated.json
@@ -31,8 +31,8 @@
   },
   "/static/js/exporting.js": {
     "date_published": "2021-05-19T00:00:00.000Z",
-    "date_modified": "2023-06-23T00:00:00.000Z",
-    "hash": "f36e2313c705b44e0779f7c34d9e34e0"
+    "date_modified": "2023-08-16T00:00:00.000Z",
+    "hash": "a2a9eaccff8895f1127a71d1821a18e4"
   },
   "/static/js/exporting.js.map": {
     "date_published": "2021-09-19T00:00:00.000Z",
@@ -46,23 +46,23 @@
   },
   "/static/js/highcharts-more.js": {
     "date_published": "2021-04-26T00:00:00.000Z",
-    "date_modified": "2023-06-23T00:00:00.000Z",
-    "hash": "78c6b81245d874b48c35f1c15376c507"
+    "date_modified": "2023-08-16T00:00:00.000Z",
+    "hash": "38d4924da68d0fdfe145f059d78840f1"
   },
   "/static/js/highcharts-more.js.map": {
     "date_published": "2021-09-19T00:00:00.000Z",
-    "date_modified": "2023-06-23T00:00:00.000Z",
-    "hash": "4d58940570fe351aebc821a4db5dac17"
+    "date_modified": "2023-08-16T00:00:00.000Z",
+    "hash": "8d31b26d9fd75b9f2749cf0fc652fb34"
   },
   "/static/js/highstock.js": {
     "date_published": "2021-04-26T00:00:00.000Z",
-    "date_modified": "2023-06-23T00:00:00.000Z",
-    "hash": "f470e10501661f6de5214aa01a7efff7"
+    "date_modified": "2023-08-16T00:00:00.000Z",
+    "hash": "a0f4226f7c89b57f57921439255b188b"
   },
   "/static/js/highstock.js.map": {
     "date_published": "2021-09-19T00:00:00.000Z",
-    "date_modified": "2023-06-23T00:00:00.000Z",
-    "hash": "515d855bc02b96ec1652a81694fb93b7"
+    "date_modified": "2023-08-16T00:00:00.000Z",
+    "hash": "6a6de9a402c29ea5b76e30b5eed6ddd9"
   },
   "/static/js/histogram.js": {
     "date_published": "2018-05-08T00:00:00.000Z",
@@ -86,8 +86,33 @@
   },
   "/static/js/send-web-vitals.js": {
     "date_published": "2022-01-03T00:00:00.000Z",
-    "date_modified": "2023-06-23T00:00:00.000Z",
-    "hash": "4fb6c384e9a793c5e97e31c99cfb28f0"
+    "date_modified": "2023-08-16T00:00:00.000Z",
+    "hash": "ed1821bcac7861208b8b2a00a2a464ea"
+  },
+  "/static/js/summaryLinked.js": {
+    "date_published": "2023-08-16T00:00:00.000Z",
+    "date_modified": "2023-08-16T00:00:00.000Z",
+    "hash": "b32dbdbd54dcc1ebe279d898967e088f"
+  },
+  "/static/js/tableGeneral.js": {
+    "date_published": "2023-08-16T00:00:00.000Z",
+    "date_modified": "2023-08-16T00:00:00.000Z",
+    "hash": "a4f2078ab915b784af46cbef85e1bd42"
+  },
+  "/static/js/tableOverview.js": {
+    "date_published": "2023-08-16T00:00:00.000Z",
+    "date_modified": "2023-08-16T00:00:00.000Z",
+    "hash": "0a9bf98ecfeeb9594fde313ae8ab8edb"
+  },
+  "/static/js/tableOverviewMulti.js": {
+    "date_published": "2023-08-16T00:00:00.000Z",
+    "date_modified": "2023-08-16T00:00:00.000Z",
+    "hash": "6d90ac2a5081aebcf8377f37dc2d98dc"
+  },
+  "/static/js/techreport.js": {
+    "date_published": "2023-08-16T00:00:00.000Z",
+    "date_modified": "2023-08-16T00:00:00.000Z",
+    "hash": "f1056af856588dfdfad0c97fc6ad92e6"
   },
   "/static/js/timeseries.js": {
     "date_published": "2018-05-08T00:00:00.000Z",
@@ -96,8 +121,8 @@
   },
   "/static/js/web-vitals.js": {
     "date_published": "2022-01-03T00:00:00.000Z",
-    "date_modified": "2023-06-23T00:00:00.000Z",
-    "hash": "3b3a8a48fe7184764f781210fc579725"
+    "date_modified": "2023-08-16T00:00:00.000Z",
+    "hash": "66e660642fbe7355520bca155685a25b"
   },
   "about.html": {
     "date_published": "2018-05-08T00:00:00.000Z",

--- a/config/last_updated.json
+++ b/config/last_updated.json
@@ -31,8 +31,8 @@
   },
   "/static/js/exporting.js": {
     "date_published": "2021-05-19T00:00:00.000Z",
-    "date_modified": "2023-08-16T00:00:00.000Z",
-    "hash": "a2a9eaccff8895f1127a71d1821a18e4"
+    "date_modified": "2023-06-23T00:00:00.000Z",
+    "hash": "f36e2313c705b44e0779f7c34d9e34e0"
   },
   "/static/js/exporting.js.map": {
     "date_published": "2021-09-19T00:00:00.000Z",
@@ -46,23 +46,23 @@
   },
   "/static/js/highcharts-more.js": {
     "date_published": "2021-04-26T00:00:00.000Z",
-    "date_modified": "2023-08-16T00:00:00.000Z",
-    "hash": "38d4924da68d0fdfe145f059d78840f1"
+    "date_modified": "2023-06-23T00:00:00.000Z",
+    "hash": "78c6b81245d874b48c35f1c15376c507"
   },
   "/static/js/highcharts-more.js.map": {
     "date_published": "2021-09-19T00:00:00.000Z",
-    "date_modified": "2023-08-16T00:00:00.000Z",
-    "hash": "8d31b26d9fd75b9f2749cf0fc652fb34"
+    "date_modified": "2023-06-23T00:00:00.000Z",
+    "hash": "4d58940570fe351aebc821a4db5dac17"
   },
   "/static/js/highstock.js": {
     "date_published": "2021-04-26T00:00:00.000Z",
-    "date_modified": "2023-08-16T00:00:00.000Z",
-    "hash": "a0f4226f7c89b57f57921439255b188b"
+    "date_modified": "2023-06-23T00:00:00.000Z",
+    "hash": "f470e10501661f6de5214aa01a7efff7"
   },
   "/static/js/highstock.js.map": {
     "date_published": "2021-09-19T00:00:00.000Z",
-    "date_modified": "2023-08-16T00:00:00.000Z",
-    "hash": "6a6de9a402c29ea5b76e30b5eed6ddd9"
+    "date_modified": "2023-06-23T00:00:00.000Z",
+    "hash": "515d855bc02b96ec1652a81694fb93b7"
   },
   "/static/js/histogram.js": {
     "date_published": "2018-05-08T00:00:00.000Z",
@@ -86,33 +86,8 @@
   },
   "/static/js/send-web-vitals.js": {
     "date_published": "2022-01-03T00:00:00.000Z",
-    "date_modified": "2023-08-16T00:00:00.000Z",
-    "hash": "ed1821bcac7861208b8b2a00a2a464ea"
-  },
-  "/static/js/summaryLinked.js": {
-    "date_published": "2023-08-16T00:00:00.000Z",
-    "date_modified": "2023-08-16T00:00:00.000Z",
-    "hash": "b32dbdbd54dcc1ebe279d898967e088f"
-  },
-  "/static/js/tableGeneral.js": {
-    "date_published": "2023-08-16T00:00:00.000Z",
-    "date_modified": "2023-08-16T00:00:00.000Z",
-    "hash": "a4f2078ab915b784af46cbef85e1bd42"
-  },
-  "/static/js/tableOverview.js": {
-    "date_published": "2023-08-16T00:00:00.000Z",
-    "date_modified": "2023-08-16T00:00:00.000Z",
-    "hash": "0a9bf98ecfeeb9594fde313ae8ab8edb"
-  },
-  "/static/js/tableOverviewMulti.js": {
-    "date_published": "2023-08-16T00:00:00.000Z",
-    "date_modified": "2023-08-16T00:00:00.000Z",
-    "hash": "6d90ac2a5081aebcf8377f37dc2d98dc"
-  },
-  "/static/js/techreport.js": {
-    "date_published": "2023-08-16T00:00:00.000Z",
-    "date_modified": "2023-08-16T00:00:00.000Z",
-    "hash": "f1056af856588dfdfad0c97fc6ad92e6"
+    "date_modified": "2023-06-23T00:00:00.000Z",
+    "hash": "4fb6c384e9a793c5e97e31c99cfb28f0"
   },
   "/static/js/timeseries.js": {
     "date_published": "2018-05-08T00:00:00.000Z",
@@ -121,8 +96,8 @@
   },
   "/static/js/web-vitals.js": {
     "date_published": "2022-01-03T00:00:00.000Z",
-    "date_modified": "2023-08-16T00:00:00.000Z",
-    "hash": "66e660642fbe7355520bca155685a25b"
+    "date_modified": "2023-06-23T00:00:00.000Z",
+    "hash": "3b3a8a48fe7184764f781210fc579725"
   },
   "about.html": {
     "date_published": "2018-05-08T00:00:00.000Z",

--- a/src/js/send-web-vitals.js
+++ b/src/js/send-web-vitals.js
@@ -1,6 +1,5 @@
 function sendWebVitals() {
 
-  let longAnimationFrames = [];
   function getLoafAttribution(attribution) {
     if (!attribution) {
       return {};
@@ -16,6 +15,7 @@ function sendWebVitals() {
       total: 0
     };
 
+    const longAnimationFrames = performance.getEntriesByType('long-animation-frame');
     longAnimationFrames.filter(loaf => {
       // LoAFs that intersect with the event.
       return entry.startTime < (loaf.startTime + loaf.duration) && loaf.startTime < (entry.startTime + entry.duration);
@@ -29,6 +29,7 @@ function sendWebVitals() {
           loafAttribution.execDuration = script.startTime + script.duration - script.executionStart;
           loafAttribution.source = script.sourceLocation || script.name;
           loafAttribution.type = script.type;
+          loafAttribution.length = longAnimationFrames.length;
         }
       });
     });
@@ -74,7 +75,7 @@ function sendWebVitals() {
           debug_loaf_exec: loafAttribution.execDuration,
           debug_loaf_source: loafAttribution.source,
           debug_loaf_type: loafAttribution.type,
-          debug_loaf_length: longAnimationFrames.length,
+          debug_loaf_length: loafAttribution.length,
         };
         if (!attribution.eventEntry) {
           break;
@@ -144,16 +145,6 @@ function sendWebVitals() {
 
     gtag('event', name, params);
 
-  }
-
-  // Monitor LoAFs
-  if (PerformanceObserver.supportedEntryTypes.includes('long-animation-frame')) {
-    new PerformanceObserver(entries => {
-      longAnimationFrames = longAnimationFrames.concat(entries.getEntries());
-    }).observe({
-      type: 'long-animation-frame',
-      buffered: true
-    });
   }
 
   // As the web-vitals script and this script is set with defer in order, so it should be loaded

--- a/src/js/send-web-vitals.js
+++ b/src/js/send-web-vitals.js
@@ -11,6 +11,10 @@ function sendWebVitals() {
       return {};
     }
 
+    if (!PerformanceObserver.supportedEntryTypes.includes('long-animation-frame')) {
+      return {};
+    }
+
     let loafAttribution = {
       debug_loaf_script_total_duration: 0
     };
@@ -33,7 +37,7 @@ function sendWebVitals() {
             debug_loaf_entry_work_duration: loaf.renderStart ? loaf.renderStart - loaf.startTime : loaf.duration,
             debug_loaf_entry_total_forced_style_and_layout_duration: loaf.scripts.reduce((sum, script) => sum + script.forcedStyleAndLayoutDuration, 0),
             debug_loaf_entry_style_and_layout_duration: loaf.styleAndLayoutStart ? loaf.startTime + loaf.duration - loaf.styleAndLayoutStart : 0,
-            
+
             // Stats for the longest script in the LoAF entry.
             debug_loaf_script_total_duration: totalDuration,
             debug_loaf_script_delay: script.startTime - script.desiredExecutionStart,

--- a/src/js/send-web-vitals.js
+++ b/src/js/send-web-vitals.js
@@ -41,7 +41,7 @@ function sendWebVitals() {
       return {};
     }
 
-    // The LoAF script with the single longest duration.
+    // The LoAF script with the single longest total duration.
     return loafAttribution;
   }
 
@@ -146,7 +146,6 @@ function sendWebVitals() {
       navigation_type: navigationType,
     }, overrides);
 
-    console.log('gtag', name, params);
     gtag('event', name, params);
 
   }

--- a/src/js/send-web-vitals.js
+++ b/src/js/send-web-vitals.js
@@ -20,10 +20,6 @@ function sendWebVitals() {
       // LoAFs that intersect with the event.
       return entry.startTime < (loaf.startTime + loaf.duration) && loaf.startTime < (entry.startTime + entry.duration);
     }).forEach(loaf => {
-      if (loaf.duration <= loafAttribution.duration) {
-        return;
-      }
-
       loaf.scripts.forEach(script => {
         const total = script.startTime + script.duration - script.desiredExecutionStart;
         if (total > loafAttribution.total) {

--- a/templates/base.html
+++ b/templates/base.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta http-equiv="origin-trial" content="AmdzWBGBdEr8AI0MG9poN2lZf9U7QRE/RoEVZG+a3x1EaKVab2JGtai0p0EMdo30PaEP6wt9sdywr+RGzzCofgYAAAB0eyJvcmlnaW4iOiJodHRwczovL2h0dHBhcmNoaXZlLm9yZzo0NDMiLCJmZWF0dXJlIjoiTG9uZ0FuaW1hdGlvbkZyYW1lVGltaW5nIiwiZXhwaXJ5IjoxNzA5NjgzMTk5LCJpc1N1YmRvbWFpbiI6dHJ1ZX0=">
 
     {% block head %}
     <title>{% block title %}HTTP Archive{% endblock %}</title>


### PR DESCRIPTION
According to Search Console, we have an INP problem on our report pages. I think this is a good opportunity to try out the new LoAF origin trial in Chrome ~115~116 to see if it helps us narrow the problem down. While it might not be _necessary_ for debugging, it's a good opportunity for us to dogfood the API.

I've registered all HA subdomains for the trial and this PR adds the meta token.

<img width="1184" alt="image" src="https://github.com/HTTPArchive/httparchive.org/assets/1120896/0ca7a704-a981-400f-93fa-68ec75f8ceb8">

