### PR TITLE
Wait to render charts until visible

### DIFF
--- a/src/js/histogram.js
+++ b/src/js/histogram.js
@@ -1,7 +1,7 @@
 import { Colors } from './colors';
 import debounce from './debounce';
 import { Metric } from './metric';
-import { el, prettyDate, chartExportOptions, drawMetricSummary } from './utils';
+import { el, prettyDate, chartExportOptions, drawMetricSummary, callOnceWhenVisible } from './utils';
 
 
 const [COLOR_DESKTOP, COLOR_MOBILE, COLOR_DESKTOP_ALT, COLOR_MOBILE_ALT] = Colors.getAll({rgba: true});
@@ -262,7 +262,10 @@ function drawHistogram(data, containerId, options) {
     });
   }
 
-  drawChart(series, containerId, options);
+  const chart = document.getElementById(`${options.metric}-chart`);
+  callOnceWhenVisible(chart, () => {
+    drawChart(series, containerId, options);
+  });
 };
 
 function drawChart(series, containerId, options) {

--- a/src/js/timeseries.js
+++ b/src/js/timeseries.js
@@ -2,7 +2,7 @@ import Changelog from './changelog';
 import { Colors } from './colors';
 import debounce from './debounce';
 import { Metric } from './metric';
-import { el, prettyDate, chartExportOptions, drawMetricSummary } from './utils';
+import { el, prettyDate, chartExportOptions, drawMetricSummary, callOnceWhenVisible } from './utils';
 
 
 function timeseries(metric, options, start, end) {
@@ -141,7 +141,10 @@ function drawTimeseries(data, options) {
     .then(flagSeries => series.push(flagSeries))
     // If the getFlagSeries request fails (503), catch so we can still draw the chart
     .catch(console.error)
-    .then(_ => drawChart(options, series));
+    .then(_ => {
+      const chart = document.getElementById(options.chartId);
+      callOnceWhenVisible(chart, () => drawChart(options, series));
+    });
 
 }
 let redrawTimeseriesTable = {};

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -58,6 +58,28 @@ export const drawMetricSummary = (options, client, value, isMedian=true, change=
   }
 };
 
+/**
+ * Invokes the callback when the element is visible for the first time.
+ * 
+ * Rendering all charts immediately at startup causes long tasks and slow INP.
+ * Instead, wait until the chart is in view before rendering.
+ * Rendering a single chart might still create a long task,
+ * but it'll be less likely to contribute to INP.
+ * 
+ * @param {HTMLElement} element 
+ * @param {Function} callback 
+ */
+export function callOnceWhenVisible(element, callback) {
+  new IntersectionObserver((entries, observer) => {
+    if (!entries[0].isIntersecting) {
+      return;
+    }
+
+    observer.unobserve(element);
+    callback();
+  }).observe(element);
+}
+
 const getQueryUrl = (metric, type) => {
   const URL_BASE = 'https://github.com/HTTPArchive/bigquery/blob/master/sql';
   if (type === 'timeseries') {

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -60,14 +60,14 @@ export const drawMetricSummary = (options, client, value, isMedian=true, change=
 
 /**
  * Invokes the callback when the element is visible for the first time.
- * 
+ *
  * Rendering all charts immediately at startup causes long tasks and slow INP.
  * Instead, wait until the chart is in view before rendering.
  * Rendering a single chart might still create a long task,
  * but it'll be less likely to contribute to INP.
- * 
- * @param {HTMLElement} element 
- * @param {Function} callback 
+ *
+ * @param {HTMLElement} element
+ * @param {Function} callback
  */
 export function callOnceWhenVisible(element, callback) {
   new IntersectionObserver((entries, observer) => {


### PR DESCRIPTION
Progress on #796 

Uses IntersectionObservers to defer rendering histogram and timeseries charts until they're in the viewport