### PR TITLE
Add a param to analytics for A/B testing

### DIFF
--- a/src/js/send-web-vitals.js
+++ b/src/js/send-web-vitals.js
@@ -155,6 +155,9 @@ function sendWebVitals() {
       prefers_reduced_motion: prefersReducedMotion,
       prefers_color_scheme: prefersColorScheme,
       navigation_type: navigationType,
+
+      // TODO(rviscomi): Remove this after A/B testing the INP optimization.
+      debug_version: 'defer-chart',
     }, overrides);
 
     gtag('event', name, params);


### PR DESCRIPTION
Progress on #796 

This change adds a `debug_version` param to the analytics with a value of `"defer-chart"`.

When releasing the recent INP improvements, we can split traffic 50/50 and use this param as a way of distinguishing the fix from the control.

I left a TODO in the code to remove the version when we're satisfied with the results and ramp traffic up to 100%. Alternatively, we could find a more permanent solution to annotate the website version (most recent last modified date?) in the version param.