### PR TITLE
Update CWV report to replace FID with INP

### DIFF
--- a/config/reports.json
+++ b/config/reports.json
@@ -566,7 +566,7 @@
     "cruxPassesCWV": {
       "name": "Passes Core Web Vitals",
       "type": "%",
-      "description": "The percentage of origins passing all three [Core Web Vitals](https://web.dev/vitals/#core-web-vitals) (LCP, FID, CLS) with a \"good\" experience. Note that if an origin is missing FID data, it's assessed based on the performance of the remaining metrics.",
+      "description": "The percentage of origins passing all three [Core Web Vitals](https://web.dev/articles/vitals#core-web-vitals) (LCP, INP, CLS) with a \"good\" experience. Note that if an origin is missing INP data, it's assessed based on the performance of the remaining metrics. Also note that prior to March 2024, this metric used FID instead of INP.",
       "downIsBad": true,
       "histogram": {
         "enabled": false
@@ -1246,10 +1246,10 @@
       "cruxSlowLcp",
       "cruxSmallCls",
       "cruxLargeCls",
-      "cruxFastFid",
-      "cruxSlowFid",
       "cruxFastInp",
       "cruxSlowInp",
+      "cruxFastFid",
+      "cruxSlowFid",
       "cruxFastTtfb",
       "cruxSlowTtfb",
       "cruxFastFp",

--- a/config/reports.json
+++ b/config/reports.json
@@ -482,7 +482,7 @@
       "name": "Cumulative Layout Shift",
       "type": "",
       "singular": "",
-      "description": "The layout shift scores for every unexpected layout shift that occurs during the entire lifespan of the page. See the [Cumulative Layout Shift (CLS)](https://web.dev/cls/) for more info.",
+      "description": "The layout shift scores for every unexpected layout shift that occurs during the entire lifespan of the page. See the [Cumulative Layout Shift (CLS)](https://web.dev/articles/cls/) for more info.",
       "timeseries": {
         "enabled": false
       },
@@ -544,7 +544,7 @@
     "cruxInp": {
       "name": "Interaction to Next Paint",
       "type": "ms",
-      "description": "The number of milliseconds from the time the user initiates an interaction to the time the page responds. See [Interaction to Next Paint (INP)](https://web.dev/inp/).",
+      "description": "The number of milliseconds from the time the user initiates an interaction to the time the page responds. See [Interaction to Next Paint (INP)](https://web.dev/articles/inp/).",
       "timeseries": {
         "enabled": false
       },
@@ -555,7 +555,7 @@
     "cruxTtfb": {
       "name": "Time to First Byte",
       "type": "ms",
-      "description": "The number of milliseconds from the time the user initiates a navigation until the first bytes are received. See [Time to First Byte (TTFB)](https://web.dev/ttfb/).",
+      "description": "The number of milliseconds from the time the user initiates a navigation until the first bytes are received. See [Time to First Byte (TTFB)](https://web.dev/articles/ttfb/).",
       "timeseries": {
         "enabled": false
       },
@@ -650,7 +650,7 @@
     "cruxFastInp": {
       "name": "Good Interaction to Next Paint",
       "type": "%",
-      "description": "The percentage of origins with \"good\" INP experiences, less than or equal to 200 ms. See [Interaction to Next Paint (INP)](https://web.dev/inp/).",
+      "description": "The percentage of origins with \"good\" INP experiences, less than or equal to 200 ms. See [Interaction to Next Paint (INP)](https://web.dev/articles/inp/).",
       "downIsBad": true,
       "histogram": {
         "enabled": false
@@ -678,7 +678,7 @@
     "cruxFastTtfb": {
       "name": "Good Time to First Byte",
       "type": "%",
-      "description": "The percentage of origins with \"good\" TTFB experiences, less than or equal to 800ms. See [Time to First Byte (TTFB)](https://web.dev/ttfb/).",
+      "description": "The percentage of origins with \"good\" TTFB experiences, less than or equal to 800ms. See [Time to First Byte (TTFB)](https://web.dev/articles/ttfb/).",
       "downIsBad": true,
       "histogram": {
         "enabled": false
@@ -732,7 +732,7 @@
     "cruxSlowInp": {
       "name": "Poor Interaction to Next Paint",
       "type": "%",
-      "description": "The percentage of origins with \"poor\" INP experiences, greater than 500 ms. See [Interaction to Next Paint (INP)](https://web.dev/inp/).",
+      "description": "The percentage of origins with \"poor\" INP experiences, greater than 500 ms. See [Interaction to Next Paint (INP)](https://web.dev/articles/inp/).",
       "histogram": {
         "enabled": false
       },
@@ -758,7 +758,7 @@
     "cruxSlowTtfb": {
       "name": "Poor Time to First Byte",
       "type": "%",
-      "description": "The percentage of origins with \"poor\" TTFB experiences, greater than 1800ms. See [Time to First Byte (TTFB)](https://web.dev/ttfb/).",
+      "description": "The percentage of origins with \"poor\" TTFB experiences, greater than 1800ms. See [Time to First Byte (TTFB)](https://web.dev/articles/ttfb/).",
       "histogram": {
         "enabled": false
       },

--- a/config/reports.json
+++ b/config/reports.json
@@ -482,7 +482,7 @@
       "name": "Cumulative Layout Shift",
       "type": "",
       "singular": "",
-      "description": "The layout shift scores for every unexpected layout shift that occurs during the entire lifespan of the page. See the [Cumulative Layout Shift (CLS)](https://web.dev/articles/cls/) for more info.",
+      "description": "The layout shift scores for every unexpected layout shift that occurs during the entire lifespan of the page. See the [Cumulative Layout Shift (CLS)](https://web.dev/articles/cls) for more info.",
       "timeseries": {
         "enabled": false
       },
@@ -544,7 +544,7 @@
     "cruxInp": {
       "name": "Interaction to Next Paint",
       "type": "ms",
-      "description": "The number of milliseconds from the time the user initiates an interaction to the time the page responds. See [Interaction to Next Paint (INP)](https://web.dev/articles/inp/).",
+      "description": "The number of milliseconds from the time the user initiates an interaction to the time the page responds. See [Interaction to Next Paint (INP)](https://web.dev/articles/inp).",
       "timeseries": {
         "enabled": false
       },
@@ -555,7 +555,7 @@
     "cruxTtfb": {
       "name": "Time to First Byte",
       "type": "ms",
-      "description": "The number of milliseconds from the time the user initiates a navigation until the first bytes are received. See [Time to First Byte (TTFB)](https://web.dev/articles/ttfb/).",
+      "description": "The number of milliseconds from the time the user initiates a navigation until the first bytes are received. See [Time to First Byte (TTFB)](https://web.dev/articles/ttfb).",
       "timeseries": {
         "enabled": false
       },
@@ -650,7 +650,7 @@
     "cruxFastInp": {
       "name": "Good Interaction to Next Paint",
       "type": "%",
-      "description": "The percentage of origins with \"good\" INP experiences, less than or equal to 200 ms. See [Interaction to Next Paint (INP)](https://web.dev/articles/inp/).",
+      "description": "The percentage of origins with \"good\" INP experiences, less than or equal to 200 ms. See [Interaction to Next Paint (INP)](https://web.dev/articles/inp).",
       "downIsBad": true,
       "histogram": {
         "enabled": false
@@ -678,7 +678,7 @@
     "cruxFastTtfb": {
       "name": "Good Time to First Byte",
       "type": "%",
-      "description": "The percentage of origins with \"good\" TTFB experiences, less than or equal to 800ms. See [Time to First Byte (TTFB)](https://web.dev/articles/ttfb/).",
+      "description": "The percentage of origins with \"good\" TTFB experiences, less than or equal to 800ms. See [Time to First Byte (TTFB)](https://web.dev/articles/ttfb).",
       "downIsBad": true,
       "histogram": {
         "enabled": false
@@ -732,7 +732,7 @@
     "cruxSlowInp": {
       "name": "Poor Interaction to Next Paint",
       "type": "%",
-      "description": "The percentage of origins with \"poor\" INP experiences, greater than 500 ms. See [Interaction to Next Paint (INP)](https://web.dev/articles/inp/).",
+      "description": "The percentage of origins with \"poor\" INP experiences, greater than 500 ms. See [Interaction to Next Paint (INP)](https://web.dev/articles/inp).",
       "histogram": {
         "enabled": false
       },
@@ -758,7 +758,7 @@
     "cruxSlowTtfb": {
       "name": "Poor Time to First Byte",
       "type": "%",
-      "description": "The percentage of origins with \"poor\" TTFB experiences, greater than 1800ms. See [Time to First Byte (TTFB)](https://web.dev/articles/ttfb/).",
+      "description": "The percentage of origins with \"poor\" TTFB experiences, greater than 1800ms. See [Time to First Byte (TTFB)](https://web.dev/articles/ttfb).",
       "histogram": {
         "enabled": false
       },


### PR DESCRIPTION
Progress on #826 

- Updates the "Passes CWV" metric description to refer to INP as one of the three CWV metrics
- Updates URLs to Web Vitals docs to skip a redirect
- Adds a note about FID being used prior to March 2024
- Rearranges INP and FID metrics in the report so that INP appears first