### PR TITLE
Update LoAF OT token

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta http-equiv="origin-trial" content="AmdzWBGBdEr8AI0MG9poN2lZf9U7QRE/RoEVZG+a3x1EaKVab2JGtai0p0EMdo30PaEP6wt9sdywr+RGzzCofgYAAAB0eyJvcmlnaW4iOiJodHRwczovL2h0dHBhcmNoaXZlLm9yZzo0NDMiLCJmZWF0dXJlIjoiTG9uZ0FuaW1hdGlvbkZyYW1lVGltaW5nIiwiZXhwaXJ5IjoxNzA5NjgzMTk5LCJpc1N1YmRvbWFpbiI6dHJ1ZX0=">
+    <meta http-equiv="origin-trial" content="AqqBKXKVFUu6Op5aphalxMRl8CECiZ0BVlee+zWMM1E9R6oLnNQPRIXd5F8gEYxahMwEzEjOYKzA3Nf6jIc08AEAAAB0eyJvcmlnaW4iOiJodHRwczovL2h0dHBhcmNoaXZlLm9yZzo0NDMiLCJmZWF0dXJlIjoiTG9uZ0FuaW1hdGlvbkZyYW1lVGltaW5nIiwiZXhwaXJ5IjoxNzE2OTQwNzk5LCJpc1N1YmRvbWFpbiI6dHJ1ZX0=">
 
     {% block head %}
     <title>{% block title %}HTTP Archive{% endblock %}</title>


### PR DESCRIPTION
The last token expired on March 6, but this one will let us bridge the gap with the stable API until March 29.

<img width="356" alt="image" src="https://github.com/HTTPArchive/httparchive.org/assets/1120896/184951eb-ef36-4122-9a55-4adc8449b48a">
