### PR TITLE
Fix  error page

### DIFF
--- a/templates/error/error.html
+++ b/templates/error/error.html
@@ -44,7 +44,7 @@
 {% block scripts %}
 {{ super() }}
 <script nonce="{{ csp_nonce() }}">
-  gtag('event', '{{ HTTP_STATUS_CODES[error.code] }}' {
+  gtag('event', '{{ HTTP_STATUS_CODES[error.code] }}', {
     'event_category': 'error',
     'event_label': '{{ request.path }}',
     'value': 1


### PR DESCRIPTION
Noticed in the SpeedCurve error logs:

> Uncaught SyntaxError: missing ) after argument list

To repro, visit any page that 404s