### PR TITLE
Remove FID from CrUX report

### DIFF
--- a/config/reports.json
+++ b/config/reports.json
@@ -518,17 +518,6 @@
         "scale": 0.001
       }
     },
-    "cruxFid": {
-      "name": "First Input Delay",
-      "type": "ms",
-      "description": "The number of milliseconds from the time the user initiates their first interaction to the time the page responds. See [FID in CrUX](https://developers.google.com/web/updates/2018/07/first-input-delay-in-crux).",
-      "timeseries": {
-        "enabled": false
-      },
-      "histogram": {
-        "minDate": "2018_06_01"
-      }
-    },
     "cruxInp": {
       "name": "Interaction to Next Paint",
       "type": "ms",
@@ -621,20 +610,6 @@
         ]
       }
     },
-    "cruxFastFid": {
-      "name": "Good First Input Delay",
-      "type": "%",
-      "description": "The percentage of origins with \"good\" FID experiences, less than or equal to 100 ms. See [FID in CrUX](https://developers.google.com/web/updates/2018/07/first-input-delay-in-crux).",
-      "downIsBad": true,
-      "histogram": {
-        "enabled": false
-      },
-      "timeseries": {
-        "fields": [
-          "percent"
-        ]
-      }
-    },
     "cruxFastInp": {
       "name": "Good Interaction to Next Paint",
       "type": "%",
@@ -695,19 +670,6 @@
       "name": "Poor First Contentful Paint",
       "type": "%",
       "description": "The percentage of origins with \"poor\" FCP experiences, greater than 3 seconds.",
-      "histogram": {
-        "enabled": false
-      },
-      "timeseries": {
-        "fields": [
-          "percent"
-        ]
-      }
-    },
-    "cruxSlowFid": {
-      "name": "Poor First Input Delay",
-      "type": "%",
-      "description": "The percentage of origins with \"poor\" FID experiences, greater than 250 ms. See [FID in CrUX](https://developers.google.com/web/updates/2018/07/first-input-delay-in-crux).",
       "histogram": {
         "enabled": false
       },
@@ -1208,8 +1170,6 @@
       "cruxLargeCls",
       "cruxFastInp",
       "cruxSlowInp",
-      "cruxFastFid",
-      "cruxSlowFid",
       "cruxFastTtfb",
       "cruxSlowTtfb",
       "cruxFastFp",
@@ -1218,7 +1178,6 @@
       "cruxFcp",
       "cruxLcp",
       "cruxCls",
-      "cruxFid",
       "cruxInp",
       "cruxTtfb",
       "cruxFp",


### PR DESCRIPTION
FID will be [dropped from Google Tooling from September](https://web.dev/blog/inp-cwv-launch?hl=en#fid_deprecation_timeline). Let's remove it from our CrUX chart.

I think we should merge this in late September/early October rather than now in case someone is still interested in this data during September (the high pass rates are one of the reasons).