### PR TITLE
Disable mouse zooming on charts

### DIFF
--- a/src/js/histogram.js
+++ b/src/js/histogram.js
@@ -281,6 +281,11 @@ function drawChart(series, containerId, options) {
           x: 0,
           y: -50
         }
+      },
+      zooming: {
+        mouseWheel: {
+          enabled: false
+        }
       }
     },
     title: {

--- a/src/js/timeseries.js
+++ b/src/js/timeseries.js
@@ -283,7 +283,12 @@ function drawChart(options, series) {
     metric: options.metric,
     type: 'timeseries',
     chart: {
-      zoomType: 'x'
+      zoomType: 'x',
+      zooming: {
+        mouseWheel: {
+          enabled: false
+        }
+      }
     },
     title: {
       text: `${options.lens ? `${options.lens.name}: ` : '' }` + `Timeseries of ${options.name}`,
@@ -420,6 +425,7 @@ function drawChart(options, series) {
       }]
     });
   };
+  chart.zooming.mousewheel.enabled = false;
   window.charts = window.charts || {};
   window.charts[options.metric] = chart;
 }


### PR DESCRIPTION
This is really annoying when you scroll down.

You can still zoom with mouse clicks or using the minimap beneath the charts.