### PR TITLE
yAxis ticks max at 100% in histogram

### DIFF
--- a/src/js/histogram.js
+++ b/src/js/histogram.js
@@ -368,7 +368,8 @@ function drawChart(series, containerId, options) {
       },
       labels: {
         format: '{value}%'
-      }
+      },
+      tickAmount: 6,
     }, {
       title: {
         text: 'Cumulative Density'
@@ -377,6 +378,7 @@ function drawChart(series, containerId, options) {
         format: '{value}%'
       },
       max: 100,
+      tickAmount: 6,
       opposite: true
     }],
     series,


### PR DESCRIPTION
[See here](https://httparchive.org/reports/state-of-the-web?start=latest&view=list) - umulative density = 105% may confuse the readers.

Round numbers are easier to read:
![httparchive org_reports_state-of-the-web_start=latest view=list](https://github.com/user-attachments/assets/e2107bab-d715-40ee-b071-a716cf661fd2)
