### PR TITLE
BQ docs link update

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -36,13 +36,9 @@ Given these conditions it's virtually impossible to compare the HTTP Archive's t
 
 ## How do I use BigQuery to write custom queries over the data?
 
-The HTTP Archive dataset is available on BigQuery. Be aware that as a consequence of collecting so much metadata from millions of websites each month, the dataset is _extremely large_—multiple petabytes. Care _must_ be taken to set up [cost controls](https://cloud.google.com/bigquery/docs/custom-quotas) to avoid unexpected bills. Also see our guide to [minimizing query costs](https://har.fyi/guides/minimizing-costs/) for tips on staying under the 1 TB per month free quota.
-
-Check out [Getting Started Accessing the HTTP Archive with BigQuery](https://har.fyi/guides/getting-started/), a guide for first-time users written by [Paul Calvano](https://twitter.com/paulcalvano).
+The HTTP Archive dataset is available publicly on BigQuery. Check out [Getting Started Accessing the HTTP Archive with BigQuery](https://har.fyi/guides/getting-started/).
 
 For a guided walkthrough of the project, watch this in-depth [30 minute video](https://www.youtube.com/watch?v=00f9kza3BJ0) featuring HTTP Archive maintainer [Rick Viscomi](https://twitter.com/rick_viscomi).
-
-If you have any questions about using BigQuery, reach out to the HTTP Archive community at [discuss.httparchive.org](https://discuss.httparchive.org/).
 
 
 ## What changes have been made to the test environment that might affect the data?

--- a/templates/index.html
+++ b/templates/index.html
@@ -69,7 +69,7 @@
       </div>
 
       <div class="col-lg-6 col-sm-6 col-md-6 hidden-xs">
-        <a href="{{ url_for('faq', _anchor=faq.ANCHOR_BIGQUERY) }}">
+        <a href="https://har.fyi/guides/getting-started/">
           <img src="/static/img/data.png" width="466" height="367" alt="Learn more about HTTP Archive on BigQuery" loading="lazy" />
         </a>
       </div>


### PR DESCRIPTION
Why do we bring users to a small paragraph in the FAQ, while we could take them directly to the docs?

And the answer duplicates the information from the guide a lot.