### PR TITLE
Use issue template for Tech Report feedback

### DIFF
--- a/templates/techreport/techreport.html
+++ b/templates/techreport/techreport.html
@@ -65,7 +65,7 @@
       <h2>Feedback?</h2>
       <p>
         We are still working on this dashboard. The design and functionality can still change, and we're working on accessibility improvements and bugfixes.
-        What you're seeing here is a snapshot of our latest GitHub commit, and are <a href="https://github.com/HTTPArchive/httparchive.org/issues">open for feedback</a>.
+        What you're seeing here is a snapshot of our latest GitHub commit, and are <a href="https://github.com/HTTPArchive/httparchive.org/issues/new?template=tech-report.md">open for feedback</a>.
       </p>
     </div>
   </div>


### PR DESCRIPTION
I made a new issue template for feedback related to the Tech Report. This updates the feedback link shown on the Tech Report to point to the template.

Right now the template just prepends "Tech Report: " to the issue title for easier tracking but we could also auto-assign people or add labels as needed.