### PR TITLE
Update performance with seo in comparison table

### DIFF
--- a/config/techreport.json
+++ b/config/techreport.json
@@ -746,18 +746,18 @@
               },
               {
                 "key": "medium_score_pct",
-                "name": "Perf.",
+                "name": "A11Y",
                 "breakdown": "subcategory",
-                "subcategory": "performance",
+                "subcategory": "accessibility",
                 "endpoint": "lighthouse",
                 "metric": "median_score_pct",
                 "viz": "progress-circle"
               },
               {
                 "key": "medium_score_pct",
-                "name": "A11Y",
+                "name": "SEO",
                 "breakdown": "subcategory",
-                "subcategory": "accessibility",
+                "subcategory": "seo",
                 "endpoint": "lighthouse",
                 "metric": "median_score_pct",
                 "viz": "progress-circle"


### PR DESCRIPTION
Fixes: https://github.com/HTTPArchive/httparchive.org/issues/1009

In multi tech comparison table:
- Performance removed from the list
- Accessibility first lighthouse column
- SEO second lighthouse column