### PR TITLE
Fix formatting table icons

### DIFF
--- a/src/js/components/drilldownHeader.js
+++ b/src/js/components/drilldownHeader.js
@@ -50,7 +50,6 @@ function update(filters) {
   if(app) {
     const formattedApp = DataUtils.formatAppName(app);
     setTitle(formattedApp);
-    console.log(app, filters);
   }
 }
 

--- a/src/js/components/drilldownHeader.js
+++ b/src/js/components/drilldownHeader.js
@@ -4,13 +4,12 @@ function setTitle(title) {
   const mainTitle = document.querySelector('h1 span.main-title');
   mainTitle.textContent = title;
 
-  const img = document.createElement('img');
-  const imgUrl = `https://cdn.httparchive.org/static/icons/${title}.png`;
-  img.setAttribute('aria-hidden', 'true');
-  img.setAttribute('alt', '');
-  img.setAttribute('src', imgUrl);
-  img.classList.add('title-img');
-  mainTitle.append(img);
+}
+
+function setIcon(icon) {
+  const img = document.querySelector('h1 .title-img');
+  const imgUrl = `https://cdn.httparchive.org/static/icons/${icon}`;
+  img.setAttribute('style', `background-image: url(${imgUrl})`);
 }
 
 function setCategories(categories) {
@@ -51,6 +50,7 @@ function update(filters) {
   if(app) {
     const formattedApp = DataUtils.formatAppName(app);
     setTitle(formattedApp);
+    console.log(app, filters);
   }
 }
 
@@ -58,4 +58,5 @@ export const DrilldownHeader = {
   update,
   setCategories,
   setDescription,
+  setIcon,
 }

--- a/src/js/techreport/index.js
+++ b/src/js/techreport/index.js
@@ -372,6 +372,7 @@ class TechReport {
         const categories = techInfo && techInfo.category ? techInfo.category.split(', ') : [];
         DrilldownHeader.setCategories(categories);
         DrilldownHeader.setDescription(techInfo.description);
+        DrilldownHeader.setIcon(techInfo.icon);
       });
   }
 
@@ -441,9 +442,9 @@ class TechReport {
 
   // Update drilldown page components
   updateDrilldownComponents(data) {
-    DrilldownHeader.update(this.filters);
-
     const app = this.filters.app[0];
+    DrilldownHeader.update(this.filters);
+    DrilldownHeader.setIcon(`${encodeURI(app)}.png`);
 
     if(data && data[app]) {
       UIUtils.updateReportComponents(this.sections, data, data[app], this.page, this.labels);

--- a/src/js/techreport/index.js
+++ b/src/js/techreport/index.js
@@ -288,6 +288,10 @@ class TechReport {
     const url = `${Constants.apiBase}/categories?category=${category}`;
     const apis = [
       {
+        endpoint: 'technologies',
+        metric: 'technologies',
+      },
+      {
         endpoint: 'cwv',
         metric: 'vitals',
         parse: DataUtils.parseVitalsData,

--- a/src/js/techreport/index.js
+++ b/src/js/techreport/index.js
@@ -209,6 +209,10 @@ class TechReport {
 
     const apis = [
       {
+        endpoint: 'technologies',
+        metric: 'technologies',
+      },
+      {
         endpoint: 'cwv',
         metric: 'vitals',
         parse: DataUtils.parseVitalsData,
@@ -237,6 +241,7 @@ class TechReport {
     const rank = this.filters.rank.replaceAll(" ", "%20");
 
     let allResults = {};
+    let techInfo = {};
     technologies.forEach(tech => allResults[tech] = []);
 
     Promise.all(apis.map(api => {
@@ -257,14 +262,19 @@ class TechReport {
               parsedRow[api.metric] = api.parse(metric, parsedRow?.date);
             }
 
-            const resIndex = allResults[row.technology].findIndex(res => res.date === row.date);
-            if(resIndex > -1) {
-              allResults[row.technology][resIndex] = {
-                ...allResults[row.technology][resIndex],
-                ...parsedRow
-              }
+            if(api.endpoint === 'technologies') {
+              techInfo[row.technology] = row;
             } else {
-              allResults[row.technology].push(parsedRow);
+              const resIndex = allResults[row.technology].findIndex(res => res.date === row.date);
+              if(resIndex > -1) {
+                allResults[row.technology][resIndex] = {
+                  ...allResults[row.technology][resIndex],
+                  ...techInfo[row.technology],
+                  ...parsedRow
+                }
+              } else {
+                allResults[row.technology].push(parsedRow);
+              }
             }
           });
         })

--- a/src/js/techreport/tableLinked.js
+++ b/src/js/techreport/tableLinked.js
@@ -79,7 +79,6 @@ class TableLinked {
         // Set the data and the app name
         const data = technology;
         const app = technology[0]?.technology;
-        const formattedApp = DataUtils.formatAppName(app);
 
         // Select the latest entry for each technology
         const sorted = data?.sort((a, b) => new Date(b.date) - new Date(a.date));
@@ -96,12 +95,13 @@ class TableLinked {
               cell.classList.add('app-cell');
 
               const img = document.createElement('span');
-              const imgUrl = `https://cdn.httparchive.org/static/icons/${formattedApp}.png`;
+              const imgUrl = `https://cdn.httparchive.org/static/icons/${app.replaceAll(' ','%20')}.png`;
               img.setAttribute('aria-hidden', 'true');
               img.setAttribute('style', `background-image: url(${imgUrl})`);
               img.classList.add('app-img');
               cell.append(img);
 
+              const formattedApp = DataUtils.formatAppName(app);
               const link = document.createElement('a');
               link.setAttribute('href', `/reports/techreport/tech?tech=${app}&geo=${geo}&rank=${rank}`);
               link.innerHTML = formattedApp;

--- a/src/js/techreport/tableLinked.js
+++ b/src/js/techreport/tableLinked.js
@@ -95,7 +95,7 @@ class TableLinked {
               cell.classList.add('app-cell');
 
               const img = document.createElement('span');
-              const imgUrl = `https://cdn.httparchive.org/static/icons/${app.replaceAll(' ','%20')}.png`;
+              const imgUrl = `https://cdn.httparchive.org/static/icons/${encodeURI(app)}.png`;
               img.setAttribute('aria-hidden', 'true');
               img.setAttribute('style', `background-image: url(${imgUrl})`);
               img.classList.add('app-img');

--- a/src/js/techreport/tableLinked.js
+++ b/src/js/techreport/tableLinked.js
@@ -95,7 +95,7 @@ class TableLinked {
               cell.classList.add('app-cell');
 
               const img = document.createElement('span');
-              const imgUrl = `https://cdn.httparchive.org/static/icons/${encodeURI(app)}.png`;
+              const imgUrl = `https://cdn.httparchive.org/static/icons/${encodeURI(technology[0]?.icon)}`;
               img.setAttribute('aria-hidden', 'true');
               img.setAttribute('style', `background-image: url(${imgUrl})`);
               img.classList.add('app-img');

--- a/src/js/techreport/tableLinked.js
+++ b/src/js/techreport/tableLinked.js
@@ -35,8 +35,6 @@ class TableLinked {
 
     this.dataArray = this.dataArray.filter(row => row.length > 0);
 
-    console.log('set content', content, this.dataArray);
-
     const isContent = content?.length > 0 || this.dataArray?.length > 0;
 
     if(tbody && isContent) {

--- a/src/js/techreport/utils/data.js
+++ b/src/js/techreport/utils/data.js
@@ -109,6 +109,10 @@ const fetchCategoryData = (rows, filters, callback) => {
   const url = `${Constants.apiBase}/categories?category=${categoryFormatted}&geo=${geoFormatted}&rank=${rankFormatted}`;
   const apis = [
     {
+      endpoint: 'technologies',
+      metric: 'technologies',
+    },
+    {
       endpoint: 'cwv',
       metric: 'vitals',
       parse: DataUtils.parseVitalsData,
@@ -168,6 +172,11 @@ const fetchCategoryData = (rows, filters, callback) => {
                   ...allResults[row.technology][resIndex],
                   ...parsedRow
                 }
+              } else if(allResults[row.technology].length === 1) {
+                allResults[row.technology][0] = {
+                  ...allResults[row.technology][0],
+                  ...parsedRow
+                }
               } else {
                 allResults[row.technology].push(parsedRow);
               }
@@ -189,6 +198,7 @@ const fetchCategoryData = (rows, filters, callback) => {
         total.forEach(t => t.textContent = Math.ceil(category?.technologies?.length / rows));
 
         /* Update components */
+        console.log(category);
         callback(category);
       });
     });

--- a/src/js/techreport/utils/data.js
+++ b/src/js/techreport/utils/data.js
@@ -198,7 +198,6 @@ const fetchCategoryData = (rows, filters, callback) => {
         total.forEach(t => t.textContent = Math.ceil(category?.technologies?.length / rows));
 
         /* Update components */
-        console.log(category);
         callback(category);
       });
     });

--- a/static/css/techreport/techreport.css
+++ b/static/css/techreport/techreport.css
@@ -1159,10 +1159,14 @@ select {
 }
 
 .title-img {
-  max-height: 1.5rem;
   margin-left: 0.5rem;
   position: relative;
   top: -0.1rem;
+  width: 1.5rem;
+  height: 1.5rem;
+  display: inline-block;
+  background-size: contain;
+  background-repeat: no-repeat;
 }
 
 .intro .heading-wrapper {

--- a/templates/techreport/category.html
+++ b/templates/techreport/category.html
@@ -149,15 +149,15 @@
               {% else %}
                 <option value="10">10</option>
               {% endif %}
-              {% if filters.rows == "25" %}
-                <option value="25" selected>25</option>
+              {% if filters.rows == "20" %}
+                <option value="20" selected>20</option>
               {% else %}
-                <option value="25">25</option>
+                <option value="20">20</option>
               {% endif %}
-              {% if filters.rows == "50" %}
-                <option value="50" selected>50</option>
+              {% if filters.rows == "30" %}
+                <option value="30" selected>30</option>
               {% else %}
-                <option value="50">50</option>
+                <option value="30">30</option>
               {% endif %}
             </select>
           </div>

--- a/templates/techreport/drilldown.html
+++ b/templates/techreport/drilldown.html
@@ -12,7 +12,10 @@
       <div class="heading-wrapper">
         <h1>
           <span class="subtitle">Technology</span>
-          <span class="main-title">ALL</span>
+          <span>
+            <span class="main-title">ALL</span>
+            <span class="title-img" role="img" aria-hidden="true"></span>
+          </span>
         </h1>
         {% include "techreport/components/filter_breakdown.html" %}
       </div>


### PR DESCRIPTION
Fixes: https://github.com/HTTPArchive/httparchive.org/issues/1012

Name of the icons is now formatted differently, changing ` ` to `%20`. Example from the issues (Framer Sites) shows an icon in the table now. 