### PR TITLE
Bugfix: Add the correct techs to the compare button when loading a page

### DIFF
--- a/src/js/components/filters.js
+++ b/src/js/components/filters.js
@@ -73,7 +73,8 @@ class Filters {
     // url.hash = '#report-content';
 
     /* Update the url */
-    location.href = url;
+    const styledUrl = url.href.replaceAll('%2C', ',');
+    location.href = styledUrl;
   }
 
   /* Update the list of technologies */

--- a/src/js/techreport/tableLinked.js
+++ b/src/js/techreport/tableLinked.js
@@ -9,11 +9,11 @@ class TableLinked {
     this.submetric = ''; // TODO: Fetch the default one from somewhere
     this.data = data;
     this.dataArray = [];
-    this.selectedTechs = this.getTechsFromURL()?.split(',') || [];
+    this.selectedTechs = DataUtils.getTechsFromURL()?.split(',') || [];
     this.rows = filters.rows || 10;
 
     this.updateContent();
-    this.updateSelectionText(this.getTechsFromURL());
+    this.updateSelectionText(DataUtils.getTechsFromURL());
 
     const rowCount = document.getElementById('rowsPerPage');
     rowCount?.addEventListener('change', (e) => this.updateRowsPerPage(e));
@@ -34,8 +34,6 @@ class TableLinked {
     }
 
     this.dataArray = this.dataArray.filter(row => row.length > 0);
-
-    console.log('set content', content, this.dataArray);
 
     const isContent = content?.length > 0 || this.dataArray?.length > 0;
 
@@ -159,11 +157,6 @@ class TableLinked {
     }
   }
 
-  getTechsFromURL() {
-    const url = new URL(window.location);
-    return url.searchParams.get('selected') || null;
-  }
-
   addColumnCheckbox(app) {
     const cell = document.createElement('td');
     const formattedApp = DataUtils.formatAppName(app);
@@ -192,7 +185,7 @@ class TableLinked {
 
   // Set selected content
   isTechSelected(app) {
-    const urlSelected = this.getTechsFromURL();
+    const urlSelected = DataUtils.getTechsFromURL();
     return urlSelected?.includes(app) || false;
   }
 

--- a/src/js/techreport/tableLinked.js
+++ b/src/js/techreport/tableLinked.js
@@ -236,7 +236,8 @@ class TableLinked {
   updateURL(param, value) {
     const url = new URL(window.location);
     url.searchParams.set(param, value);
-    window.history.replaceState(null, null, url);
+    const styledUrl = url.href.replaceAll('%2C', ',');
+    window.history.replaceState(null, null, styledUrl);
   }
 
   updateSelectionText(allSelectedApps) {

--- a/src/js/techreport/utils/data.js
+++ b/src/js/techreport/utils/data.js
@@ -139,10 +139,12 @@ const fetchCategoryData = (rows, filters, callback) => {
       const lastTechNr = pageNr * rows;
       const paginatedTechs = category?.technologies?.slice(firstTechNr, lastTechNr);
 
-      const technologyFormatted = encodeURI(paginatedTechs?.join('%2C'));
+      const techsFromUrl = getTechsFromURL();
+      const technologyFormatted = paginatedTechs?.join(',');
+      const technologyUrl = encodeURI(techsFromUrl || technologyFormatted);
 
       const compare = document.querySelector('[data-name="selected-apps"]');
-      compare.setAttribute('href', `/reports/techreport/tech?tech=${technologyFormatted}`);
+      compare.setAttribute('href', `/reports/techreport/tech?tech=${technologyUrl}`);
 
       let allResults = {};
       paginatedTechs.forEach(tech => allResults[tech] = []);
@@ -194,6 +196,11 @@ const fetchCategoryData = (rows, filters, callback) => {
     });
 }
 
+const getTechsFromURL = () => {
+  const url = new URL(window.location);
+  return url.searchParams.get('selected') || null;
+}
+
 export const DataUtils = {
   parseVitalsData,
   parseLighthouseData,
@@ -203,4 +210,5 @@ export const DataUtils = {
   getLighthouseScoreCategories,
   formatAppName,
   fetchCategoryData,
+  getTechsFromURL,
 };


### PR DESCRIPTION
Previous behavior in the categories page: on pageload, regardless if any technologies were selected from the URL or not, the "compare technologies" button above the table compared _all_ technologies on the page. Additionally, the URL it led to was formatted wrong (one long string with `%2C` as a separator instead of commas), and as a result the compare page didn't work.

Updated code: 
- Checks first if techs are selected or not
- If any techs are selected, those are used
- If not, all techs on the page are used
- Then the list is separated by comma before being encoded

Result:
- Enter the page with no techs selected → Link leads to: Comparison page with all techs in the table
- Enter the page with one or more techs selected → Link leads to: Comparison page with the selected techs
- The actual techs are loaded in the comparison page