### PR TITLE
Bugfix: Remove disabled state when adding new tech

### DIFF
--- a/src/js/components/filters.js
+++ b/src/js/components/filters.js
@@ -216,6 +216,7 @@ class Filters {
     const techId = `tech-${techNr}`;
     const techLabel = `Technology ${techNr}`;
     selectElement.setAttribute('id', techId);
+    selectElement.removeAttribute('disabled');
     labelElement.setAttribute('for', techId);
     labelElement.textContent = techLabel;
 


### PR DESCRIPTION
Last PR introduced a bug: when clicking the "add new tech" button, a disabled dropdown was added to the filters. 
Updated: the `disabled` attribute is removed from new dropdowns added.

Fixes: https://github.com/HTTPArchive/httparchive.org/issues/1036