### PR TITLE
Lighthouse changes

### DIFF
--- a/config/techreport.json
+++ b/config/techreport.json
@@ -122,23 +122,23 @@
           },
           {
             "endpoint": "lighthouse",
-            "category": "performance",
+            "category": "accessibility",
             "metric": "median_score_pct",
-            "label": "Lighthouse performance",
+            "label": "Lighthouse Accessibility",
             "suffix": "",
             "change": "true",
-            "description": "Median lighthouse performance score across tested origins.",
-            "url": "#lighthouse"
+            "description": "Median Lighthouse Accessibility score across tested origins.",
+            "url": "?median-lighthouse-over-time=accessibility#lighthouse"
           },
           {
             "endpoint": "lighthouse",
-            "category": "accessibility",
+            "category": "seo",
             "metric": "median_score_pct",
-            "label": "Lighthouse accessibility",
+            "label": "Lighthouse SEO",
             "suffix": "",
             "change": "true",
-            "description": "Median lighthouse accessibility score across tested origins.",
-            "url": "#lighthouse&median-lighthouse-over-time=accessibility"
+            "description": "Median Lighthouse SEO score across tested origins.",
+            "url": "?median-lighthouse-over-time=seo#lighthouse"
           },
           {
             "endpoint": "pageWeight",
@@ -421,7 +421,7 @@
           }
         },
         "lighthouse_summary": {
-          "title": "Latest lighthouse scores",
+          "title": "Latest Lighthouse scores",
           "cards": [
             {
               "endpoint": "lighthouse",
@@ -483,7 +483,7 @@
                 "value": "accessibility"
               },
               {
-                "label": "SEO (Search Engine Optimisation)",
+                "label": "SEO (Search Engine Optimization)",
                 "value": "seo"
               },
               {
@@ -970,7 +970,7 @@
               },
               {
                 "key": "median_score_pct",
-                "name": "Median lighthouse score",
+                "name": "Median Lighthouse score",
                 "breakdown": "app",
                 "className": "main-cell",
                 "viz": "progress-circle"


### PR DESCRIPTION
Makes a few changes to Lighthouse in the new tech report
- Changes the Performance SEO and also moves a11y up a notch - similar to #1009
- Consistently uses capital for Lighthouse in labels since it's a brand name
- Consistently uses capital letter for category (Accessibility not accessibility) when talking about the audits categories.
- Fixes some links