### PR TITLE
#1066: When month over month change value doesn't exist, don't add or try to style it 

### DIFF
--- a/src/js/techreport/summaryCards.js
+++ b/src/js/techreport/summaryCards.js
@@ -73,14 +73,14 @@ class SummaryCard {
         });
       }
 
-      if(latestChange && latestChange.string) {
+      if(latestChange && latestChange.string && latestChange.perc) {
         const changeSlot = card.querySelector('[data-slot="change"]');
         const changeMeaning = changeSlot?.dataset?.meaning;
 
         if(changeSlot) {
           changeSlot.textContent = latestChange.string;
           const styling = UIUtils.getChangeStatus(latestChange.perc, changeMeaning);
-          changeSlot.classList.add(styling.color, styling.direction);
+          changeSlot.classList.add(styling?.color, styling?.direction);
         }
       }
     }

--- a/src/js/techreport/table.js
+++ b/src/js/techreport/table.js
@@ -194,7 +194,7 @@ function updateTable(id, config, appConfig, apps, data) {
       }
 
       if(column.styling) {
-        wrapper.classList.add('monthchange', column.styling.direction, column.styling.color);
+        wrapper.classList.add('monthchange', column.styling?.direction, column.styling?.color);
       }
 
       // Add cell to the row

--- a/src/js/techreport/timeseries.js
+++ b/src/js/techreport/timeseries.js
@@ -175,7 +175,7 @@ class Timeseries {
           const styling = UIUtils.getChangeStatus(latestMoM, changeMeaning);
           const monthChange = document.createElement('span');
           monthChange.textContent = latestMoMStr;
-          monthChange.classList.add('monthchange', styling.color, styling.direction);
+          monthChange.classList.add('monthchange', styling?.color, styling.direction);
           itemWrapper.appendChild(monthChange);
         }
 
@@ -250,7 +250,7 @@ class Timeseries {
           const styling = UIUtils.getChangeStatus(latestMoM, changeMeaning);
           const monthChange = document.createElement('span');
           monthChange.textContent = latestMoMStr;
-          monthChange.classList.add('monthchange', styling.color, styling.direction);
+          monthChange.classList.add('monthchange', styling?.color, styling.direction);
           card.appendChild(monthChange);
         }
       }

--- a/src/js/techreport/utils/ui.js
+++ b/src/js/techreport/utils/ui.js
@@ -35,13 +35,6 @@ const updateReportComponents = (sections, data) => {
 }
 
 const getChangeStatus = (percentage, meaning) => {
-  if(percentage === 0) {
-    return {
-      direction: 'equal',
-      color: 'neutral'
-    }
-  }
-
   if(percentage > 0) {
     const color = meaning === 'inverted' ? 'bad' : 'good';
     return {
@@ -56,6 +49,11 @@ const getChangeStatus = (percentage, meaning) => {
       direction: 'negative',
       color: color,
     }
+  }
+
+  return {
+    direction: 'equal',
+    color: 'neutral'
   }
 }
 


### PR DESCRIPTION
See issue: https://github.com/HTTPArchive/httparchive.org/issues/1066

For some smaller geos, the month over month change returns null. If that's the case, the MoM stat isn't show in the summary cards. As an extra protection, we're also first checking if the styling object exists before trying to call on its color/direction value (`styling?.color` instead of `styling.color`).