### PR TITLE
Safe int conversion for query parameters

### DIFF
--- a/server/routes.py
+++ b/server/routes.py
@@ -99,7 +99,7 @@ def techreportlanding(page_id):
     requested_geo = request.args.get("geo") or "ALL"
     requested_rank = request.args.get("rank") or "ALL"
     requested_category = request.args.get("category") or "CMS"
-    requested_page = safe_int(request.args.get("page"))
+    requested_page = safe_int(request.args.get("page"))  # TODO: After security scanner is off, return 400 if not an int
     selected_techs = request.args.get("selected")
     selected_rows = str(safe_int(request.args.get("rows"), default=10))
 

--- a/server/routes.py
+++ b/server/routes.py
@@ -8,6 +8,16 @@ from . import techreport as tech_report_util
 from . import faq as faq_util
 
 
+def safe_int(value, default=1):
+    """
+    Safely convert a value to integer, default to 1 if conversion fails.
+    """
+    try:
+        return int(value) if value else default
+    except (ValueError, TypeError):
+        return default
+
+
 @app.route("/")
 def index():
     return render_template(
@@ -89,11 +99,9 @@ def techreportlanding(page_id):
     requested_geo = request.args.get("geo") or "ALL"
     requested_rank = request.args.get("rank") or "ALL"
     requested_category = request.args.get("category") or "CMS"
-    requested_page = request.args.get("page") or 1
-    requested_page = int(requested_page)
+    requested_page = safe_int(request.args.get("page"))
     selected_techs = request.args.get("selected")
-    selected_rows = request.args.get("rows") or 10
-    selected_rows = str(selected_rows)
+    selected_rows = str(safe_int(request.args.get("rows"), default=10))
 
     last_page = request.args.get("last_page") or False
 

--- a/server/routes.py
+++ b/server/routes.py
@@ -99,7 +99,9 @@ def techreportlanding(page_id):
     requested_geo = request.args.get("geo") or "ALL"
     requested_rank = request.args.get("rank") or "ALL"
     requested_category = request.args.get("category") or "CMS"
-    requested_page = safe_int(request.args.get("page"))  # TODO: After security scanner is off, return 400 if not an int
+    requested_page = safe_int(
+        request.args.get("page")
+    )  # TODO: After security scanner is off, return 400 if not an int
     selected_techs = request.args.get("selected")
     selected_rows = str(safe_int(request.args.get("rows"), default=10))
 

--- a/server/tests/routes_test.py
+++ b/server/tests/routes_test.py
@@ -239,9 +239,7 @@ def test_tech_report_drilldown_wordpress(client):
 
 
 def test_tech_report_category(client):
-    response = client.get(
-        "/reports/techreport/category?geo=ALL&rank=ALL&category=CMS"
-    )
+    response = client.get("/reports/techreport/category?geo=ALL&rank=ALL&category=CMS")
     assert response.status_code == 200
 
 

--- a/server/tests/routes_test.py
+++ b/server/tests/routes_test.py
@@ -234,9 +234,7 @@ def test_tech_report_drilldown(client):
 
 
 def test_tech_report_drilldown_wordpress(client):
-    response = client.get(
-        "/reports/techreport/tech?tech=WordPress&geo=ALL&rank=ALL"
-    )
+    response = client.get("/reports/techreport/tech?tech=WordPress&geo=ALL&rank=ALL")
     assert response.status_code == 200
 
 
@@ -248,12 +246,16 @@ def test_tech_report_category(client):
 
 
 def test_tech_report_category_pages(client):
-    response = client.get("/reports/techreport/category?geo=ALL&rank=ALL&category=CMS&page=2")
+    response = client.get(
+        "/reports/techreport/category?geo=ALL&rank=ALL&category=CMS&page=2"
+    )
     assert response.status_code == 200
 
 
 def test_tech_report_category_pages_fallback(client):
-    response = client.get("/reports/techreport/category?geo=ALL&rank=ALL&category=CMS&page=defaults_to_1")
+    response = client.get(
+        "/reports/techreport/category?geo=ALL&rank=ALL&category=CMS&page=defaults_to_1"
+    )
     assert response.status_code == 200
 
 

--- a/server/tests/routes_test.py
+++ b/server/tests/routes_test.py
@@ -243,6 +243,16 @@ def test_tech_report_category(client):
     assert response.status_code == 200
 
 
+def test_tech_report_category_pages(client):
+    response = client.get("/reports/techreport/category?geo=ALL&rank=ALL&category=CMS&page=2")
+    assert response.status_code == 200
+
+
+def test_tech_report_category_pages_fallback(client):
+    response = client.get("/reports/techreport/category?geo=ALL&rank=ALL&category=CMS&page=defaults_to_1")
+    assert response.status_code == 200
+
+
 def test_well_known_atproto_did(client):
     response = client.get("/.well-known/atproto-did")
     assert response.status_code == 200


### PR DESCRIPTION
- [x] safe int conversion for numerical query params

  Lots of 500 in logs: https://cloudlogging.app.goo.gl/tUXGV92PUkmsegiPA

  And one more argument to switch off security scanner.


- [x] reverted some false linting pushed to `main` by mistake.