### PR TITLE
Add 404 error handling for tech report

### DIFF
--- a/server/routes.py
+++ b/server/routes.py
@@ -1,11 +1,14 @@
-from flask import redirect, request, jsonify, abort, send_from_directory
 import re
 
+from flask import abort, jsonify, redirect, request, send_from_directory
 
-from . import app, talisman, render_template, url_for
-from . import reports as report_util
-from . import techreport as tech_report_util
+from . import app
 from . import faq as faq_util
+from . import render_template
+from . import reports as report_util
+from . import talisman
+from . import techreport as tech_report_util
+from . import url_for
 
 
 def safe_int(value, default=1):
@@ -87,6 +90,10 @@ def techreportlanding(page_id):
 
     # Get the settings for the current page
     active_tech_report = tech_report.get("pages").get(page_id)
+
+    # Check if the page exists
+    if active_tech_report is None:
+        abort(404)
 
     # Add the technologies requested in the URL to the filters
     # Use the default configured techs as fallback

--- a/server/tests/routes_test.py
+++ b/server/tests/routes_test.py
@@ -12,8 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from server import app, talisman
 import pytest
+
+from server import app, talisman
 
 
 # Create test client without https redirect
@@ -255,6 +256,31 @@ def test_tech_report_category_pages_fallback(client):
         "/reports/techreport/category?geo=ALL&rank=ALL&category=CMS&page=defaults_to_1"
     )
     assert response.status_code == 200
+
+
+def test_tech_report_landing_valid_page(client):
+    response = client.get("/reports/techreport/landing")
+    assert response.status_code == 200
+
+
+def test_tech_report_drilldown_page(client):
+    response = client.get("/reports/techreport/drilldown")
+    assert response.status_code == 200
+
+
+def test_tech_report_comparison_page(client):
+    response = client.get("/reports/techreport/comparison")
+    assert response.status_code == 200
+
+
+def test_tech_report_category_page(client):
+    response = client.get("/reports/techreport/category")
+    assert response.status_code == 200
+
+
+def test_tech_report_invalid_page(client):
+    response = client.get("/reports/techreport/invalid_page_id")
+    assert response.status_code == 404
 
 
 def test_well_known_atproto_did(client):

--- a/templates/error/404.html
+++ b/templates/error/404.html
@@ -4,9 +4,5 @@
 {% block error %}Page Not Found{% endblock %}
 
 {% block custom %}
-<p>
-  We've recently <a href="https://discuss.httparchive.org/t/announcing-the-new-http-archive/1294">launched a new version of the HTTP Archive</a>.
-  Some URLs may have been updated, please take a look at our new site!
-  If the information you're looking for is missing, please <a href="https://discuss.httparchive.org/t/announcing-the-new-http-archive/1294">let us know</a>.
-</p>
+<p>If the information you're looking for is missing, please <a href="https://github.com/HTTPArchive/httparchive.org/issues/new?template=BLANK_ISSUE">let us know</a>.</p>
 {% endblock %}

--- a/templates/error/404.html
+++ b/templates/error/404.html
@@ -4,5 +4,5 @@
 {% block error %}Page Not Found{% endblock %}
 
 {% block custom %}
-<p>If the information you're looking for is missing, please <a href="https://github.com/HTTPArchive/httparchive.org/issues/new?template=BLANK_ISSUE">let us know</a>.</p>
+<p>If the information you're looking for is missing, please <a href="https://github.com/HTTPArchive/httparchive.org/issues/new?template=BLANK_ISSUE" target="_blank">let us know</a>.</p>
 {% endblock %}

--- a/tools/scripts/set_lighthouse_urls.sh
+++ b/tools/scripts/set_lighthouse_urls.sh
@@ -60,7 +60,7 @@ elif [ "${RUN_TYPE}" == "pull_request" ] && [ "${COMMIT_SHA}" != "" ]; then
     git pull --quiet
     git checkout main
     # Then get the changes
-    CHANGED_FILES=$(git diff --name-only "main...${COMMIT_SHA}" --diff-filter=d templates config/reports.json | grep -v base.html | grep -v main.html | grep -v ejs | grep -v base_ | grep -v sitemap | grep -v error.html | grep -v techreport/components | grep -v techreport/templates | grep -v techreport/report | grep -v techreport/techreport)
+    CHANGED_FILES=$(git diff --name-only "main...${COMMIT_SHA}" --diff-filter=d templates config/reports.json | grep -v base.html | grep -v main.html | grep -v ejs | grep -v base_ | grep -v sitemap | grep -v error.html | grep -v techreport/components | grep -v techreport/templates | grep -v techreport/report | grep -v techreport/techreport) | grep -v 404
     echo "${CHANGED_FILES}"
 
     # Then back to the pull request changes

--- a/tools/scripts/set_lighthouse_urls.sh
+++ b/tools/scripts/set_lighthouse_urls.sh
@@ -60,7 +60,7 @@ elif [ "${RUN_TYPE}" == "pull_request" ] && [ "${COMMIT_SHA}" != "" ]; then
     git pull --quiet
     git checkout main
     # Then get the changes
-    CHANGED_FILES=$(git diff --name-only "main...${COMMIT_SHA}" --diff-filter=d templates config/reports.json | grep -v base.html | grep -v main.html | grep -v ejs | grep -v base_ | grep -v sitemap | grep -v error.html | grep -v techreport/components | grep -v techreport/templates | grep -v techreport/report | grep -v techreport/techreport) | grep -v 404
+    CHANGED_FILES=$(git diff --name-only "main...${COMMIT_SHA}" --diff-filter=d templates config/reports.json | grep -v base.html | grep -v main.html | grep -v ejs | grep -v base_ | grep -v sitemap | grep -v error.html | grep -v techreport/components | grep -v techreport/templates | grep -v techreport/report | grep -v techreport/techreport | grep -v 404)
     echo "${CHANGED_FILES}"
 
     # Then back to the pull request changes


### PR DESCRIPTION
Related to [the errors](https://console.cloud.google.com/errors/detail/CJqT5uagy4TYFQ;locations=global?project=httparchive)

To reproduce: https://httparchive.org/reports/techreport/vefsfvfs
