### PR TITLE
Potential fix for code scanning alert no. 69: Semicolon insertion

### DIFF
--- a/src/js/histogram.js
+++ b/src/js/histogram.js
@@ -268,7 +268,7 @@ function drawHistogram(data, containerId, options) {
   const chart = document.getElementById(`${options.metric}-chart`);
   callOnceWhenVisible(chart, () => {
     drawChart(series, containerId, options);
-  })
+  });
 }
 
 function drawChart(series, containerId, options) {


### PR DESCRIPTION
Potential fix for [https://github.com/HTTPArchive/httparchive.org/security/code-scanning/69](https://github.com/HTTPArchive/httparchive.org/security/code-scanning/69)

To fix the problem, we should explicitly terminate the `callOnceWhenVisible` function call on line 271 with a semicolon, instead of relying on JavaScript’s automatic semicolon insertion. This means that after the line `270:     drawChart(series, containerId, options);` and the closing bracket and parenthesis on line `271:   })`, we add a semicolon, making it `271:   });`. This edit should be made only to line 271. No other changes or imports are needed, as this is a pure style fix that does not change any logic.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
