### PR TITLE
Add meta for summaries in Drilldown report

### DIFF
--- a/templates/techreport/drilldown.html
+++ b/templates/techreport/drilldown.html
@@ -60,6 +60,7 @@
               {% include "techreport/components/summary_card.html" %}
             {% endfor %}
           </div>
+          {% include "techreport/components/filter_meta.html" %}
         {% endif %}
 
         <div class="card">
@@ -87,6 +88,7 @@
               {% include "techreport/components/summary_card.html" %}
             {% endfor %}
           </div>
+          {% include "techreport/components/filter_meta.html" %}
         {% endif %}
 
         <div class="card">
@@ -114,6 +116,7 @@
               {% include "techreport/components/summary_card.html" %}
             {% endfor %}
           </div>
+          {% include "techreport/components/filter_meta.html" %}
         {% endif %}
 
         <div class="card">


### PR DESCRIPTION
<img width="1190" height="692" alt="image" src="https://github.com/user-attachments/assets/c77cd4ee-617a-411d-a3c9-0dc1dd774977" />

The summary cards are for a device, even if the graph is not. And I removed the device from the meta data in #1153 (but it wasn't a great place for it there anyway as not ).

Let's add it to the summary cards, even if it feels a little duplicative:

<img width="996" height="624" alt="image" src="https://github.com/user-attachments/assets/74104a8d-d58f-4aed-84b0-799901acb300" />
