### PR TITLE
Set logging level for MARKDOWN to INFO

### DIFF
--- a/server/__init__.py
+++ b/server/__init__.py
@@ -36,6 +36,7 @@ from .legacy import Legacy
 
 
 logging.basicConfig(level=logging.DEBUG)
+logging.getLogger("MARKDOWN").setLevel(logging.INFO)
 
 ROOT_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..")
 TEMPLATES_DIR = ROOT_DIR + "/templates"


### PR DESCRIPTION
Skip debug logs for Markdown package that contributes 150K logs per day
See here: https://cloudlogging.app.goo.gl/ysMm1ZSRiMU5gFrD6