### PR TITLE
Add Core Web Vitals distribution histogram to tech report

### DIFF
--- a/config/last_updated.json
+++ b/config/last_updated.json
@@ -51,8 +51,8 @@
   },
   "/static/css/techreport/techreport.css": {
     "date_published": "2023-10-09T00:00:00.000Z",
-    "date_modified": "2026-03-24T00:00:00.000Z",
-    "hash": "fed0915210b6a05bb8430623fe296586"
+    "date_modified": "2026-04-14T00:00:00.000Z",
+    "hash": "5a211ca184de3cd5731dfedaa1af929d"
   },
   "/static/js/accessibility.js": {
     "date_published": "2023-10-09T00:00:00.000Z",
@@ -166,18 +166,23 @@
   },
   "/static/js/techreport.js": {
     "date_published": "2023-10-09T00:00:00.000Z",
-    "date_modified": "2026-03-10T00:00:00.000Z",
+    "date_modified": "2026-04-14T00:00:00.000Z",
     "hash": "dfcef45ae09e7c2fcd3ab825e9503729"
+  },
+  "/static/js/techreport/cwvDistribution.js": {
+    "date_published": "2026-04-07T00:00:00.000Z",
+    "date_modified": "2026-04-14T00:00:00.000Z",
+    "hash": "a9e884b2786b23670ac13e2c8a121183"
   },
   "/static/js/techreport/geoBreakdown.js": {
     "date_published": "2026-03-24T00:00:00.000Z",
-    "date_modified": "2026-03-24T00:00:00.000Z",
-    "hash": "030573b2da410620601352f9f6df8695"
+    "date_modified": "2026-04-14T00:00:00.000Z",
+    "hash": "2eab1a9b9c47001e8f5f757d041f4897"
   },
   "/static/js/techreport/section.js": {
     "date_published": "2023-10-09T00:00:00.000Z",
-    "date_modified": "2026-03-24T00:00:00.000Z",
-    "hash": "376404acd77a2e5adeab188a9b5ccb94"
+    "date_modified": "2026-04-07T00:00:00.000Z",
+    "hash": "c813fe60fb1bcd338221f72b64739701"
   },
   "/static/js/techreport/timeseries.js": {
     "date_published": "2023-10-09T00:00:00.000Z",
@@ -191,8 +196,8 @@
   },
   "/static/js/web-vitals.js": {
     "date_published": "2022-01-03T00:00:00.000Z",
-    "date_modified": "2025-08-18T00:00:00.000Z",
-    "hash": "e7b8ecda99703fdc7c6a33b6a3d07cc6"
+    "date_modified": "2026-04-07T00:00:00.000Z",
+    "hash": "1b30cb4e8907aa62bc9045690570a4eb"
   },
   "about.html": {
     "date_published": "2018-05-08T00:00:00.000Z",

--- a/config/techreport.json
+++ b/config/techreport.json
@@ -734,6 +734,18 @@
             { "label": "Good FCP", "value": "FCP" },
             { "label": "Good TTFB", "value": "TTFB" }
           ]
+        },
+        "cwv_distribution": {
+          "id": "cwv_distribution",
+          "title": "Core Web Vitals distribution",
+          "description": "How origins are distributed across performance buckets for individual Core Web Vitals metrics. Green, orange, and red zones indicate good, needs improvement, and poor thresholds respectively.",
+          "metric_options": [
+            { "label": "LCP", "value": "LCP" },
+            { "label": "CLS", "value": "CLS" },
+            { "label": "INP", "value": "INP" },
+            { "label": "FCP", "value": "FCP" },
+            { "label": "TTFB", "value": "TTFB" }
+          ]
         }
       }
     },

--- a/config/techreport.json
+++ b/config/techreport.json
@@ -737,8 +737,8 @@
         },
         "cwv_distribution": {
           "id": "cwv_distribution",
-          "title": "Core Web Vitals distribution",
-          "description": "How origins are distributed across performance buckets for individual Core Web Vitals metrics. Green, orange, and red zones indicate good, needs improvement, and poor thresholds respectively.",
+          "title": "Core Web Vitals histograms",
+          "description": "How origins are distributed for individual Core Web Vitals metrics. Green, orange, and red zones indicate good, needs improvement, and poor thresholds respectively.",
           "metric_options": [
             { "label": "LCP", "value": "LCP" },
             { "label": "CLS", "value": "CLS" },

--- a/config/techreport.json
+++ b/config/techreport.json
@@ -15,6 +15,13 @@
       "INP",
       "TTFB"
     ],
+    "cwv_thresholds": {
+      "LCP":  [{ "value": 2500, "label": "Good" }, { "value": 4000, "label": "Needs improvement" }],
+      "FCP":  [{ "value": 1800, "label": "Good" }, { "value": 3000, "label": "Needs improvement" }],
+      "TTFB": [{ "value": 800,  "label": "Good" }, { "value": 1800, "label": "Needs improvement" }],
+      "INP":  [{ "value": 200,  "label": "Good" }, { "value": 500,  "label": "Needs improvement" }],
+      "CLS":  [{ "value": 0.1,  "label": "Good" }, { "value": 0.25, "label": "Needs improvement" }]
+    },
     "lighthouse_subcategories": [
       "accessibility",
       "best_practices",
@@ -726,26 +733,76 @@
           "id": "geo_breakdown",
           "title": "Core Web Vitals geographic breakdown",
           "description": "Top geographies by number of origins, showing the percentage with good Core Web Vitals and individual metrics.",
-          "metric_options": [
-            { "label": "Good Core Web Vitals", "value": "overall" },
-            { "label": "Good LCP", "value": "LCP" },
-            { "label": "Good INP", "value": "INP" },
-            { "label": "Good CLS", "value": "CLS" },
-            { "label": "Good FCP", "value": "FCP" },
-            { "label": "Good TTFB", "value": "TTFB" }
-          ]
+          "metric_labels": {
+            "overall": "Good Core Web Vitals",
+            "LCP": "Good LCP",
+            "INP": "Good INP",
+            "CLS": "Good CLS",
+            "FCP": "Good FCP",
+            "TTFB": "Good TTFB"
+          }
         },
         "cwv_distribution": {
           "id": "cwv_distribution",
           "title": "Core Web Vitals histograms",
           "description": "How origins are distributed for individual Core Web Vitals metrics. Green, orange, and red zones indicate good, needs improvement, and poor thresholds respectively.",
-          "metric_options": [
-            { "label": "LCP", "value": "LCP" },
-            { "label": "CLS", "value": "CLS" },
-            { "label": "INP", "value": "INP" },
-            { "label": "FCP", "value": "FCP" },
-            { "label": "TTFB", "value": "TTFB" }
-          ]
+          "metric_config": {
+            "LCP":  {
+              "label": "LCP",
+              "bucketField": "loading_bucket",
+              "originsField": "lcp_origins",
+              "unit": "ms",
+              "axis_label": "LCP (ms)",
+              "step": 100
+            },
+            "FCP":  {
+              "label": "FCP",
+              "bucketField": "loading_bucket",
+              "originsField": "fcp_origins",
+              "unit": "ms",
+              "axis_label": "FCP (ms)",
+              "step": 100
+            },
+            "TTFB": {
+              "label": "TTFB",
+              "bucketField": "loading_bucket",
+              "originsField": "ttfb_origins",
+              "unit": "ms",
+              "axis_label": "TTFB (ms)",
+              "step": 100 },
+            "INP":  {
+              "label": "INP",
+              "bucketField": "inp_bucket",
+              "originsField": "inp_origins",
+              "unit": "ms",
+              "axis_label": "INP (ms)",
+              "step": 25
+            },
+            "CLS":  {
+              "label": "CLS",
+              "bucketField": "cls_bucket",
+              "originsField": "cls_origins",
+              "unit": "",
+              "axis_label": "CLS",
+              "step": 0.05
+            }
+          },
+          "zone_colors": {
+            "light": {
+              "good": "#0CCE6B",
+              "needsImprovement": "#FFA400",
+              "poor": "#FF4E42",
+              "text": "#444",
+              "gridLine": "#e6e6e6"
+            },
+            "dark": {
+              "good": "#0CCE6B",
+              "needsImprovement": "#FBBC04",
+              "poor": "#FF6659",
+              "text": "#ccc",
+              "gridLine": "#444"
+            }
+          }
         }
       }
     },

--- a/src/js/techreport/cwvDistribution.js
+++ b/src/js/techreport/cwvDistribution.js
@@ -3,31 +3,12 @@
 import { Constants } from './utils/constants';
 import { UIUtils } from './utils/ui';
 
-const METRIC_CONFIG = {
-  LCP:  { bucketField: 'loading_bucket', originsField: 'lcp_origins',  unit: 'ms', label: 'LCP (ms)', step: 100 },
-  FCP:  { bucketField: 'loading_bucket', originsField: 'fcp_origins',  unit: 'ms', label: 'FCP (ms)', step: 100 },
-  TTFB: { bucketField: 'loading_bucket', originsField: 'ttfb_origins', unit: 'ms', label: 'TTFB (ms)', step: 100 },
-  INP:  { bucketField: 'inp_bucket',     originsField: 'inp_origins',  unit: 'ms', label: 'INP (ms)', step: 25 },
-  CLS:  { bucketField: 'cls_bucket',     originsField: 'cls_origins',  unit: '',   label: 'CLS', step: 0.05 },
-};
-
-const THRESHOLDS = {
-  LCP:  [{ value: 2500, label: 'Good' }, { value: 4000, label: 'Needs improvement' }],
-  FCP:  [{ value: 1800, label: 'Good' }, { value: 3000, label: 'Needs improvement' }],
-  TTFB: [{ value: 800,  label: 'Good' }, { value: 1800, label: 'Needs improvement' }],
-  INP:  [{ value: 200,  label: 'Good' }, { value: 500,  label: 'Needs improvement' }],
-  CLS:  [{ value: 0.1,  label: 'Good' }, { value: 0.25, label: 'Needs improvement' }],
-};
-
-const ZONE_COLORS = {
-  light: { good: '#0CCE6B', needsImprovement: '#FFA400', poor: '#FF4E42', text: '#444', gridLine: '#e6e6e6' },
-  dark:  { good: '#0CCE6B', needsImprovement: '#FBBC04', poor: '#FF6659', text: '#ccc', gridLine: '#444' },
-};
-
 class CwvDistribution {
   // eslint-disable-next-line no-unused-vars -- pageConfig, config, data satisfy the Section component contract
   constructor(id, pageConfig, config, filters, data) {
     this.id = id;
+    this.pageConfig = pageConfig;
+    this.config = config;
     this.pageFilters = filters;
     this.distributionData = null;
     this.chart = null;
@@ -50,7 +31,7 @@ class CwvDistribution {
 
   // Map the shared metric value (which may be 'overall') to a metric this chart can show
   resolveMetric(value) {
-    if (value && METRIC_CONFIG[value]) return METRIC_CONFIG[value];
+    if (value && this.pageConfig.cwv_distribution.metric_config[value]) return this.pageConfig.cwv_distribution.metric_config[value].label;
     return 'LCP';
   }
 
@@ -181,8 +162,8 @@ class CwvDistribution {
     if (!this.root) return;
 
     const client = this.root.dataset.client || 'mobile';
-    const metricCfg = METRIC_CONFIG[this.selectedMetric];
-    const thresholds = THRESHOLDS[this.selectedMetric];
+    const metricCfg = this.pageConfig.cwv_distribution.metric_config[this.selectedMetric];
+    const thresholds = this.config.cwv_thresholds[this.selectedMetric];
 
     const clientRows = this.distributionData
       .filter(row => row.client === client)
@@ -210,7 +191,7 @@ class CwvDistribution {
     }
 
     const theme = document.querySelector('html').dataset.theme;
-    const zoneColors = theme === 'dark' ? ZONE_COLORS.dark : ZONE_COLORS.light;
+    const zoneColors = theme === 'dark' ? this.pageConfig.cwv_distribution.zone_colors.dark : this.pageConfig.cwv_distribution.zone_colors.light;
 
     const getColor = (val) => {
       if (val < thresholds[0].value) return zoneColors.good;
@@ -256,7 +237,7 @@ class CwvDistribution {
       title: { text: null },
       xAxis: {
         categories,
-        title: { text: metricCfg.label, style: { color: textColor } },
+        title: { text: metricCfg.axis_label, style: { color: textColor } },
         labels: {
           step: Math.ceil(categories.length / 20),
           rotation: -45,

--- a/src/js/techreport/cwvDistribution.js
+++ b/src/js/techreport/cwvDistribution.js
@@ -30,16 +30,16 @@ class CwvDistribution {
     this.id = id;
     this.pageFilters = filters;
     this.distributionData = null;
-    this.selectedMetric = 'LCP';
     this.chart = null;
     this.root = document.querySelector(`[data-id="${this.id}"]`);
     this.date = this.pageFilters.end || this.root?.dataset?.latestDate || '';
+    this.selectedMetric = this.resolveMetric(new URLSearchParams(window.location.search).get('good-cwv-over-time'));
 
     // Populate "Latest data" timestamp immediately
     const tsSlot = this.root?.querySelector('[data-slot="cwv-distribution-timestamp"]');
     if (tsSlot && this.date) tsSlot.textContent = UIUtils.printMonthYear(this.date);
 
-
+    this.updateTitle();
     this.bindEventListeners();
 
     // Auto-expand if URL hash targets this section
@@ -48,14 +48,27 @@ class CwvDistribution {
     }
   }
 
+  // Map the shared metric value (which may be 'overall') to a metric this chart can show
+  resolveMetric(value) {
+    if (value && METRIC_CONFIG[value]) return value;
+    return 'LCP';
+  }
+
+  updateTitle() {
+    const slot = this.root?.querySelector('[data-slot="cwv-distribution-title-metric"]');
+    if (slot) slot.textContent = this.selectedMetric;
+  }
+
   bindEventListeners() {
     if (!this.root) return;
 
-    this.root.querySelectorAll('.cwv-distribution-metric-selector').forEach(dropdown => {
-      dropdown.addEventListener('change', event => {
-        this.selectedMetric = event.target.value;
+    document.addEventListener('cwv-metric-change', (event) => {
+      const resolved = this.resolveMetric(event.detail?.value);
+      if (resolved !== this.selectedMetric) {
+        this.selectedMetric = resolved;
+        this.updateTitle();
         if (this.distributionData) this.renderChart();
-      });
+      }
     });
 
     const btn = document.getElementById('cwv-distribution-btn');
@@ -71,7 +84,7 @@ class CwvDistribution {
     const btn = document.getElementById('cwv-distribution-btn');
     if (show) {
       this.root.classList.remove('hidden');
-      if (btn) btn.textContent = 'Hide distribution';
+      if (btn) btn.textContent = 'Hide histogram';
       if (!this.distributionData) {
         this.fetchData();
       } else if (this.chart) {
@@ -79,7 +92,7 @@ class CwvDistribution {
       }
     } else {
       this.root.classList.add('hidden');
-      if (btn) btn.textContent = 'Show distribution';
+      if (btn) btn.textContent = 'Show histogram';
     }
   }
 

--- a/src/js/techreport/cwvDistribution.js
+++ b/src/js/techreport/cwvDistribution.js
@@ -1,0 +1,285 @@
+/* global Highcharts */
+
+import { Constants } from './utils/constants';
+import { UIUtils } from './utils/ui';
+
+const METRIC_CONFIG = {
+  LCP:  { bucketField: 'loading_bucket', originsField: 'lcp_origins',  unit: 'ms', label: 'LCP (ms)', step: 100 },
+  FCP:  { bucketField: 'loading_bucket', originsField: 'fcp_origins',  unit: 'ms', label: 'FCP (ms)', step: 100 },
+  TTFB: { bucketField: 'loading_bucket', originsField: 'ttfb_origins', unit: 'ms', label: 'TTFB (ms)', step: 100 },
+  INP:  { bucketField: 'inp_bucket',     originsField: 'inp_origins',  unit: 'ms', label: 'INP (ms)', step: 25 },
+  CLS:  { bucketField: 'cls_bucket',     originsField: 'cls_origins',  unit: '',   label: 'CLS', step: 0.05 },
+};
+
+const THRESHOLDS = {
+  LCP:  [{ value: 2500, label: 'Good' }, { value: 4000, label: 'Needs improvement' }],
+  FCP:  [{ value: 1800, label: 'Good' }, { value: 3000, label: 'Needs improvement' }],
+  TTFB: [{ value: 800,  label: 'Good' }, { value: 1800, label: 'Needs improvement' }],
+  INP:  [{ value: 200,  label: 'Good' }, { value: 500,  label: 'Needs improvement' }],
+  CLS:  [{ value: 0.1,  label: 'Good' }, { value: 0.25, label: 'Needs improvement' }],
+};
+
+const ZONE_COLORS = {
+  light: { good: '#0CCE6B', needsImprovement: '#FFA400', poor: '#FF4E42', text: '#444', gridLine: '#e6e6e6' },
+  dark:  { good: '#0CCE6B', needsImprovement: '#FBBC04', poor: '#FF6659', text: '#ccc', gridLine: '#444' },
+};
+
+class CwvDistribution {
+  // eslint-disable-next-line no-unused-vars -- pageConfig, config, data satisfy the Section component contract
+  constructor(id, pageConfig, config, filters, data) {
+    this.id = id;
+    this.pageFilters = filters;
+    this.distributionData = null;
+    this.selectedMetric = 'LCP';
+    this.chart = null;
+    this.root = document.querySelector(`[data-id="${this.id}"]`);
+    this.date = this.pageFilters.end || this.root?.dataset?.latestDate || '';
+
+    // Populate "Latest data" timestamp immediately
+    const tsSlot = this.root?.querySelector('[data-slot="cwv-distribution-timestamp"]');
+    if (tsSlot && this.date) tsSlot.textContent = UIUtils.printMonthYear(this.date);
+
+
+    this.bindEventListeners();
+
+    // Auto-expand if URL hash targets this section
+    if (window.location.hash === `#section-${this.id}`) {
+      this.toggle(true);
+    }
+  }
+
+  bindEventListeners() {
+    if (!this.root) return;
+
+    this.root.querySelectorAll('.cwv-distribution-metric-selector').forEach(dropdown => {
+      dropdown.addEventListener('change', event => {
+        this.selectedMetric = event.target.value;
+        if (this.distributionData) this.renderChart();
+      });
+    });
+
+    const btn = document.getElementById('cwv-distribution-btn');
+    if (btn) {
+      btn.addEventListener('click', () => {
+        const isVisible = !this.root.classList.contains('hidden');
+        this.toggle(!isVisible);
+      });
+    }
+  }
+
+  toggle(show) {
+    const btn = document.getElementById('cwv-distribution-btn');
+    if (show) {
+      this.root.classList.remove('hidden');
+      if (btn) btn.textContent = 'Hide distribution';
+      if (!this.distributionData) {
+        this.fetchData();
+      } else if (this.chart) {
+        this.chart.reflow();
+      }
+    } else {
+      this.root.classList.add('hidden');
+      if (btn) btn.textContent = 'Show distribution';
+    }
+  }
+
+  get chartContainer() {
+    return document.getElementById(`${this.id}-chart`);
+  }
+
+  updateContent() {
+    if (this.distributionData) this.renderChart();
+  }
+
+  showLoader() {
+    if (!this.chartContainer) return;
+    this.chartContainer.innerHTML = '<div class="cwv-distribution-loader"><div class="cwv-distribution-spinner"></div><p>Loading distribution data…</p></div>';
+  }
+
+  hideLoader() {
+    if (!this.chartContainer) return;
+    const loader = this.chartContainer.querySelector('.cwv-distribution-loader');
+    if (loader) loader.remove();
+  }
+
+  showError() {
+    if (!this.chartContainer) return;
+    this.chartContainer.innerHTML = '<div class="cwv-distribution-error">Distribution data is not available for this selection.</div>';
+  }
+
+  fetchData() {
+    this.showLoader();
+
+    const technology = this.pageFilters.app.map(encodeURIComponent).join(',');
+    const rank = encodeURIComponent(this.pageFilters.rank || 'ALL');
+    const geo = encodeURIComponent(this.pageFilters.geo || 'ALL');
+    let url = `${Constants.apiBase}/cwv-distribution?technology=${technology}&rank=${rank}&geo=${geo}`;
+    if (this.date) {
+      url += `&date=${encodeURIComponent(this.date)}`;
+    }
+
+    fetch(url)
+      .then(r => {
+        if (!r.ok) throw new Error(`HTTP ${r.status}`);
+        return r.json();
+      })
+      .then(rows => {
+        if (!Array.isArray(rows) || rows.length === 0) throw new Error('Empty response');
+        this.distributionData = rows;
+        this.hideLoader();
+        this.renderChart();
+      })
+      .catch(err => {
+        console.error('CWV Distribution fetch error:', err);
+        this.showError();
+      });
+  }
+
+  trimWithOverflow(rows, originsField, percentile) {
+    const total = rows.reduce((sum, row) => sum + row[originsField], 0);
+    if (total === 0) return { visible: rows, overflowCount: 0 };
+
+    const cutoff = total * percentile;
+    let cumulative = 0;
+    let cutIndex = rows.length;
+    for (let i = 0; i < rows.length; i++) {
+      cumulative += rows[i][originsField];
+      if (cumulative >= cutoff) {
+        cutIndex = Math.min(i + 2, rows.length);
+        break;
+      }
+    }
+
+    const visible = rows.slice(0, cutIndex);
+    const visibleSum = visible.reduce((sum, row) => sum + row[originsField], 0);
+    return { visible, overflowCount: total - visibleSum };
+  }
+
+  renderChart() {
+    if (!this.distributionData || this.distributionData.length === 0) return;
+    if (!this.root) return;
+
+    const client = this.root.dataset.client || 'mobile';
+    const metricCfg = METRIC_CONFIG[this.selectedMetric];
+    const thresholds = THRESHOLDS[this.selectedMetric];
+
+    const clientRows = this.distributionData
+      .filter(row => row.client === client)
+      .sort((a, b) => a[metricCfg.bucketField] - b[metricCfg.bucketField]);
+
+    const { visible, overflowCount } = this.trimWithOverflow(
+      clientRows, metricCfg.originsField, 0.995
+    );
+
+    const formatBucket = (val) => {
+      if (metricCfg.unit === 'ms') {
+        return val >= 1000 ? `${(val / 1000).toFixed(1)}s` : `${val}ms`;
+      }
+      return String(val);
+    };
+
+    const categories = visible.map(row => formatBucket(row[metricCfg.bucketField]));
+    const seriesData = visible.map(row => row[metricCfg.originsField]);
+
+    if (overflowCount > 0) {
+      const rawNext = visible[visible.length - 1][metricCfg.bucketField] + metricCfg.step;
+      const nextBucket = Math.round(rawNext * 1e6) / 1e6;
+      categories.push(`${formatBucket(nextBucket)}+`);
+      seriesData.push(overflowCount);
+    }
+
+    const theme = document.querySelector('html').dataset.theme;
+    const zoneColors = theme === 'dark' ? ZONE_COLORS.dark : ZONE_COLORS.light;
+
+    const getColor = (val) => {
+      if (val < thresholds[0].value) return zoneColors.good;
+      if (val < thresholds[1].value) return zoneColors.needsImprovement;
+      return zoneColors.poor;
+    };
+
+    const colors = visible.map(row => getColor(row[metricCfg.bucketField]));
+    if (overflowCount > 0) {
+      colors.push(zoneColors.poor);
+    }
+
+    if (this.chart) {
+      this.chart.destroy();
+      this.chart = null;
+    }
+
+    if (!this.chartContainer) return;
+    const chartContainerId = `${this.id}-chart`;
+
+    const textColor = zoneColors.text;
+    const gridLineColor = zoneColors.gridLine;
+
+    const plotLineColors = [zoneColors.good, zoneColors.needsImprovement];
+    const plotLines = thresholds.map((t, i) => {
+      const idx = visible.findIndex(row => row[metricCfg.bucketField] >= t.value);
+      if (idx === -1) return null;
+      return {
+        value: idx - 0.5,
+        color: plotLineColors[i],
+        width: 2,
+        dashStyle: 'Dash',
+        label: {
+          text: `${t.label} (${metricCfg.unit ? t.value + metricCfg.unit : t.value})`,
+          style: { fontSize: '11px', color: textColor },
+        },
+        zIndex: 5,
+      };
+    }).filter(Boolean);
+
+    this.chart = Highcharts.chart(chartContainerId, {
+      chart: { type: 'column', backgroundColor: 'transparent' },
+      title: { text: null },
+      xAxis: {
+        categories,
+        title: { text: metricCfg.label, style: { color: textColor } },
+        labels: {
+          step: Math.ceil(categories.length / 20),
+          rotation: -45,
+          style: { color: textColor },
+          formatter: function () {
+            const lastIndex = categories.length - 1;
+            const labelStep = Math.ceil(categories.length / 20);
+            if (this.pos === lastIndex || this.pos % labelStep === 0) {
+              return this.value;
+            }
+            return null;
+          },
+        },
+        lineColor: gridLineColor,
+        plotLines,
+      },
+      yAxis: {
+        title: { text: 'Number of origins', style: { color: textColor } },
+        labels: { style: { color: textColor } },
+        gridLineColor,
+        min: 0,
+      },
+      legend: { enabled: false },
+      tooltip: {
+        formatter: function () {
+          return `<b>${this.x}</b><br/>Origins: <b>${this.y.toLocaleString()}</b>`;
+        },
+      },
+      plotOptions: {
+        column: {
+          pointPadding: 0,
+          groupPadding: 0,
+          borderWidth: 0,
+          borderRadius: 0,
+          crisp: false,
+        },
+      },
+      series: [{
+        name: 'Origins',
+        data: seriesData.map((value, i) => ({ y: value, color: colors[i] })),
+      }],
+      credits: { enabled: false },
+    });
+  }
+}
+
+window.CwvDistribution = CwvDistribution;

--- a/src/js/techreport/cwvDistribution.js
+++ b/src/js/techreport/cwvDistribution.js
@@ -50,7 +50,7 @@ class CwvDistribution {
 
   // Map the shared metric value (which may be 'overall') to a metric this chart can show
   resolveMetric(value) {
-    if (value && METRIC_CONFIG[value]) return value;
+    if (value && METRIC_CONFIG[value]) return METRIC_CONFIG[value];
     return 'LCP';
   }
 
@@ -90,9 +90,17 @@ class CwvDistribution {
       } else if (this.chart) {
         this.chart.reflow();
       }
+      // Update the URL
+      const url = new URL(window.location.href);
+      url.hash = `#section-${this.id}`;
+      window.history.replaceState(null, null, url);
     } else {
       this.root.classList.add('hidden');
       if (btn) btn.textContent = 'Show histogram';
+      // Update the URL
+      const url = new URL(window.location.href);
+      url.hash = '';
+      window.history.replaceState(null, null, url);
     }
   }
 

--- a/src/js/techreport/geoBreakdown.js
+++ b/src/js/techreport/geoBreakdown.js
@@ -1,6 +1,15 @@
 import { Constants } from './utils/constants';
 import { UIUtils } from './utils/ui';
 
+const METRIC_CONFIG = {
+  overall: 'overall',
+  LCP: 'LCP',
+  FCP: 'FCP',
+  TTFB: 'TTFB',
+  INP: 'INP',
+  CLS: 'CLS',
+};
+
 class GeoBreakdown {
   constructor(id, pageConfig, config, filters, data) {
     this.id = id;
@@ -9,7 +18,7 @@ class GeoBreakdown {
     this.pageFilters = filters;
     this.data = data;
     this.geoData = null;
-    this.selectedMetric = new URLSearchParams(window.location.search).get('good-cwv-over-time') || 'overall';
+    this.selectedMetric = this.resolveMetric(new URLSearchParams(window.location.search).get('good-cwv-over-time')) || 'overall';
     this.sortColumn = 'total';
     this.sortDir = 'desc';
     this.showAll = false;
@@ -21,6 +30,12 @@ class GeoBreakdown {
     if (window.location.hash === `#section-${this.id}`) {
       this.toggle(true);
     }
+  }
+
+  // Map the shared metric value (which may be 'overall') to a metric this chart can show
+  resolveMetric(value) {
+    if (value && METRIC_CONFIG[value]) return value;
+    return 'LCP';
   }
 
   toggle(show) {

--- a/src/js/techreport/geoBreakdown.js
+++ b/src/js/techreport/geoBreakdown.js
@@ -9,11 +9,12 @@ class GeoBreakdown {
     this.pageFilters = filters;
     this.data = data;
     this.geoData = null;
-    this.selectedMetric = 'overall';
+    this.selectedMetric = new URLSearchParams(window.location.search).get('good-cwv-over-time') || 'overall';
     this.sortColumn = 'total';
     this.sortDir = 'desc';
     this.showAll = false;
 
+    this.updateTitle();
     this.bindEventListeners();
 
     // Auto-expand if URL hash targets this section
@@ -37,13 +38,20 @@ class GeoBreakdown {
     }
   }
 
+  updateTitle() {
+    const slot = document.querySelector('[data-slot="geo-title-metric"]');
+    if (!slot) return;
+    slot.textContent = this.selectedMetric === 'overall' ? 'Core Web Vitals' : this.selectedMetric;
+  }
+
   bindEventListeners() {
-    const root = `[data-id="${this.id}"]`;
-    document.querySelectorAll(`${root} .geo-metric-selector`).forEach(dropdown => {
-      dropdown.addEventListener('change', event => {
-        this.selectedMetric = event.target.value;
+    document.addEventListener('cwv-metric-change', (event) => {
+      const value = event.detail?.value;
+      if (value && value !== this.selectedMetric) {
+        this.selectedMetric = value;
+        this.updateTitle();
         if (this.geoData) this.renderTable();
-      });
+      }
     });
 
     const btn = document.getElementById('geo-breakdown-btn');

--- a/src/js/techreport/geoBreakdown.js
+++ b/src/js/techreport/geoBreakdown.js
@@ -25,7 +25,7 @@ class GeoBreakdown {
 
   // Map the shared metric value (which may be 'overall') to a metric this chart can show
   resolveMetric(value) {
-    if (value && this.pageConfig.geo_breakdown.metric_labels.value) return value;
+    if (value && this.pageConfig.geo_breakdown.metric_labels.value) return this.pageConfig.geo_breakdown.metric_labels.value;
     return 'overall';
   }
 

--- a/src/js/techreport/geoBreakdown.js
+++ b/src/js/techreport/geoBreakdown.js
@@ -34,8 +34,8 @@ class GeoBreakdown {
 
   // Map the shared metric value (which may be 'overall') to a metric this chart can show
   resolveMetric(value) {
-    if (value && METRIC_CONFIG[value]) return value;
-    return 'LCP';
+    if (value && METRIC_CONFIG[value]) return METRIC_CONFIG[value];
+    return 'overall';
   }
 
   toggle(show) {
@@ -47,9 +47,17 @@ class GeoBreakdown {
       if (!this.geoData) {
         this.fetchData();
       }
+      // Update the URL
+      const url = new URL(window.location.href);
+      url.hash = `#section-${this.id}`;
+      window.history.replaceState(null, null, url);
     } else {
       if (wrapper) wrapper.classList.add('hidden');
       if (btn) btn.textContent = 'Show geographic breakdown';
+      // Update the URL
+      const url = new URL(window.location.href);
+      url.hash = '';
+      window.history.replaceState(null, null, url);
     }
   }
 

--- a/src/js/techreport/geoBreakdown.js
+++ b/src/js/techreport/geoBreakdown.js
@@ -1,15 +1,6 @@
 import { Constants } from './utils/constants';
 import { UIUtils } from './utils/ui';
 
-const METRIC_CONFIG = {
-  overall: 'overall',
-  LCP: 'LCP',
-  FCP: 'FCP',
-  TTFB: 'TTFB',
-  INP: 'INP',
-  CLS: 'CLS',
-};
-
 class GeoBreakdown {
   constructor(id, pageConfig, config, filters, data) {
     this.id = id;
@@ -34,7 +25,7 @@ class GeoBreakdown {
 
   // Map the shared metric value (which may be 'overall') to a metric this chart can show
   resolveMetric(value) {
-    if (value && METRIC_CONFIG[value]) return METRIC_CONFIG[value];
+    if (value && this.pageConfig.geo_breakdown.metric_labels.value) return value;
     return 'overall';
   }
 

--- a/src/js/techreport/geoBreakdown.js
+++ b/src/js/techreport/geoBreakdown.js
@@ -15,7 +15,26 @@ class GeoBreakdown {
     this.showAll = false;
 
     this.bindEventListeners();
-    this.fetchData();
+
+    // Auto-expand if URL hash targets this section
+    if (window.location.hash === `#section-${this.id}`) {
+      this.toggle(true);
+    }
+  }
+
+  toggle(show) {
+    const wrapper = document.getElementById(`section-${this.id}`);
+    const btn = document.getElementById('geo-breakdown-btn');
+    if (show) {
+      if (wrapper) wrapper.classList.remove('hidden');
+      if (btn) btn.textContent = 'Hide geographic breakdown';
+      if (!this.geoData) {
+        this.fetchData();
+      }
+    } else {
+      if (wrapper) wrapper.classList.add('hidden');
+      if (btn) btn.textContent = 'Show geographic breakdown';
+    }
   }
 
   bindEventListeners() {
@@ -26,9 +45,33 @@ class GeoBreakdown {
         if (this.geoData) this.renderTable();
       });
     });
+
+    const btn = document.getElementById('geo-breakdown-btn');
+    if (btn) {
+      btn.addEventListener('click', () => {
+        const wrapper = document.getElementById(`section-${this.id}`);
+        const isVisible = wrapper && !wrapper.classList.contains('hidden');
+        this.toggle(!isVisible);
+      });
+    }
+  }
+
+  showLoader() {
+    const container = document.getElementById(`${this.id}-table`);
+    if (!container) return;
+    container.innerHTML = '<div class="cwv-distribution-loader"><div class="cwv-distribution-spinner"></div><p>Loading geographic data…</p></div>';
+  }
+
+  hideLoader() {
+    const container = document.getElementById(`${this.id}-table`);
+    if (!container) return;
+    const loader = container.querySelector('.cwv-distribution-loader');
+    if (loader) loader.remove();
   }
 
   fetchData() {
+    this.showLoader();
+
     const technology = this.pageFilters.app.map(encodeURIComponent).join(',');
     const rank = encodeURIComponent(this.pageFilters.rank || 'ALL');
     const end = this.pageFilters.end ? `&end=${encodeURIComponent(this.pageFilters.end)}` : '';
@@ -38,9 +81,13 @@ class GeoBreakdown {
       .then(r => r.json())
       .then(rows => {
         this.geoData = rows;
+        this.hideLoader();
         this.renderTable();
       })
-      .catch(err => console.error('GeoBreakdown fetch error:', err));
+      .catch(err => {
+        console.error('GeoBreakdown fetch error:', err);
+        this.hideLoader();
+      });
   }
 
   updateContent() {

--- a/src/js/techreport/section.js
+++ b/src/js/techreport/section.js
@@ -1,4 +1,4 @@
-/* global Timeseries, GeoBreakdown */
+/* global Timeseries, GeoBreakdown, CwvDistribution */
 
 import SummaryCard from "./summaryCards";
 import TableLinked from "./tableLinked";
@@ -35,6 +35,10 @@ class Section {
 
         case "geoBreakdown":
           this.initializeGeoBreakdown(component);
+          break;
+
+        case "cwvDistribution":
+          this.initializeCwvDistribution(component);
           break;
 
         default:
@@ -75,6 +79,16 @@ class Section {
 
   initializeGeoBreakdown(component) {
     this.components[component.dataset.id] = new GeoBreakdown(
+      component.dataset.id,
+      this.pageConfig,
+      this.config,
+      this.pageFilters,
+      this.data
+    );
+  }
+
+  initializeCwvDistribution(component) {
+    this.components[component.dataset.id] = new CwvDistribution(
       component.dataset.id,
       this.pageConfig,
       this.config,

--- a/src/js/techreport/timeseries.js
+++ b/src/js/techreport/timeseries.js
@@ -46,6 +46,11 @@ class Timeseries {
       // Re-render the content
       this.updateContent();
       this.updateInfo(metric, endpoint);
+
+      // Broadcast metric change so linked components (geo breakdown, distribution) update
+      if (event.target.dataset.param === 'good-cwv-over-time') {
+        document.dispatchEvent(new CustomEvent('cwv-metric-change', { detail: { value: metric } }));
+      }
     }
   }
 

--- a/src/js/techreport/timeseries.js
+++ b/src/js/techreport/timeseries.js
@@ -58,6 +58,7 @@ class Timeseries {
   toggleTable(event) {
     const button = event.target;
     const tableWrapper = document.getElementById(`${button.dataset.id}-table-wrapper`);
+    if (!tableWrapper) return;
     if(tableWrapper.classList.contains('hidden')) {
       button.textContent = 'Hide table';
       tableWrapper.classList.remove('hidden');

--- a/static/css/techreport/techreport.css
+++ b/static/css/techreport/techreport.css
@@ -2355,12 +2355,6 @@ path.highcharts-tick {
   margin-top: 0.5rem;
 }
 
-.cwv-button-bar > .geo-breakdown-wrapper,
-.cwv-button-bar > .cwv-distribution-wrapper,
-.cwv-button-bar > [id$="-table-wrapper"] {
-  flex-basis: 100%;
-  order: 1;
-}
 
 /* CWV Distribution histogram */
 .cwv-distribution-wrapper {
@@ -2377,12 +2371,8 @@ path.highcharts-tick {
   overflow-x: auto;
 }
 
-.cwv-distribution-header {
-  display: flex;
-  flex-wrap: wrap;
-  justify-content: space-between;
-  align-items: flex-start;
-  gap: 1rem;
+.cwv-distribution-header h3 {
+  margin-top: 0;
 }
 
 .cwv-distribution-header .descr {

--- a/static/css/techreport/techreport.css
+++ b/static/css/techreport/techreport.css
@@ -1922,8 +1922,12 @@ h2.summary-heading {
 /* -------------------- */
 
 /* Highcharts */
-.highcharts-background,
-.highcharts-point {
+.highcharts-background {
+  fill: var(--color-card-background) !important;
+}
+
+.highcharts-line-series .highcharts-point,
+.highcharts-spline-series .highcharts-point {
   fill: var(--color-card-background) !important;
 }
 
@@ -2336,3 +2340,91 @@ path.highcharts-tick {
     min-width: 7.5rem;
   }
 }
+
+/* Hide original "Show table" button — replaced by one in the button bar */
+#good-cwvs .card > [data-component="timeseries"] > .show-table {
+  display: none;
+}
+
+
+/* CWV button bar (Show table, geographic breakdown, distribution) */
+.cwv-button-bar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-top: 0.5rem;
+}
+
+.cwv-button-bar > .geo-breakdown-wrapper,
+.cwv-button-bar > .cwv-distribution-wrapper,
+.cwv-button-bar > [id$="-table-wrapper"] {
+  flex-basis: 100%;
+  order: 1;
+}
+
+/* CWV Distribution histogram */
+.cwv-distribution-wrapper {
+  margin-top: 1rem;
+  border-top: 1px solid var(--color-border);
+  padding-top: 1rem;
+}
+
+/* Geographic breakdown wrapper */
+.geo-breakdown-wrapper {
+  margin-top: 1rem;
+  border-top: 1px solid var(--color-border);
+  padding-top: 1rem;
+  overflow-x: auto;
+}
+
+.cwv-distribution-header {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 1rem;
+}
+
+.cwv-distribution-header .descr {
+  max-width: 30rem;
+}
+
+.cwv-distribution-wrapper [id$="-chart"] {
+  width: 100%;
+  overflow-x: auto;
+}
+
+.cwv-distribution-wrapper .meta {
+  margin-bottom: 1rem;
+}
+
+.cwv-distribution-loader {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 3rem 1rem;
+  gap: 1rem;
+  color: var(--color-text-lighter);
+}
+
+.cwv-distribution-spinner {
+  width: 2rem;
+  height: 2rem;
+  border: 3px solid var(--color-border);
+  border-top-color: var(--color-teal);
+  border-radius: 50%;
+  animation: cwv-spin 0.8s linear infinite;
+}
+
+@keyframes cwv-spin {
+  to { transform: rotate(360deg); }
+}
+
+.cwv-distribution-error {
+  padding: 2rem 1rem;
+  text-align: center;
+  color: var(--color-text-lighter);
+  font-style: italic;
+}
+

--- a/templates/techreport/components/cwv_distribution.html
+++ b/templates/techreport/components/cwv_distribution.html
@@ -1,0 +1,44 @@
+{% set cwv_distribution_config = tech_report_page.config.cwv_distribution %}
+
+<button class="btn show-table cwv-distribution-toggle" type="button" id="cwv-distribution-btn">
+  Show distribution
+</button>
+
+<div
+  id="section-{{ cwv_distribution_config.id }}"
+  class="cwv-distribution-wrapper hidden"
+  data-id="{{ cwv_distribution_config.id }}"
+  data-component="cwvDistribution"
+  data-client="{{ request.args.get('client', '') or 'mobile' }}"
+  data-latest-date="{{ all_dates[0].value if all_dates else '' }}"
+>
+  <div class="cwv-distribution-header">
+    <div>
+      <h3><a href="#section-{{ cwv_distribution_config.id }}" class="anchor">{{ cwv_distribution_config.title }}</a></h3>
+      <p class="descr">{{ cwv_distribution_config.description }}</p>
+      <h4 class="heading">Latest data: <span data-slot="cwv-distribution-timestamp"></span></h4>
+      {% include "techreport/components/filter_meta.html" %}
+    </div>
+    <div class="component-filters">
+      <div class="subcategory-selector-wrapper">
+        <div class="position-wrapper">
+          <label for="cwv-distribution-metric-selector">Metric</label>
+          <select
+            class="cwv-distribution-metric-selector"
+            id="cwv-distribution-metric-selector"
+          >
+            {% for option in cwv_distribution_config.metric_options %}
+              {% if option.value == 'LCP' %}
+              <option value="{{ option.value }}" selected>{{ option.label }}</option>
+              {% else %}
+              <option value="{{ option.value }}">{{ option.label }}</option>
+              {% endif %}
+            {% endfor %}
+          </select>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div id="{{ cwv_distribution_config.id }}-chart"></div>
+</div>

--- a/templates/techreport/components/cwv_distribution.html
+++ b/templates/techreport/components/cwv_distribution.html
@@ -1,9 +1,5 @@
 {% set cwv_distribution_config = tech_report_page.config.cwv_distribution %}
 
-<button class="btn show-table cwv-distribution-toggle" type="button" id="cwv-distribution-btn">
-  Show distribution
-</button>
-
 <div
   id="section-{{ cwv_distribution_config.id }}"
   class="cwv-distribution-wrapper hidden"
@@ -13,31 +9,10 @@
   data-latest-date="{{ all_dates[0].value if all_dates else '' }}"
 >
   <div class="cwv-distribution-header">
-    <div>
-      <h3><a href="#section-{{ cwv_distribution_config.id }}" class="anchor">{{ cwv_distribution_config.title }}</a></h3>
-      <p class="descr">{{ cwv_distribution_config.description }}</p>
-      <h4 class="heading">Latest data: <span data-slot="cwv-distribution-timestamp"></span></h4>
-      {% include "techreport/components/filter_meta.html" %}
-    </div>
-    <div class="component-filters">
-      <div class="subcategory-selector-wrapper">
-        <div class="position-wrapper">
-          <label for="cwv-distribution-metric-selector">Metric</label>
-          <select
-            class="cwv-distribution-metric-selector"
-            id="cwv-distribution-metric-selector"
-          >
-            {% for option in cwv_distribution_config.metric_options %}
-              {% if option.value == 'LCP' %}
-              <option value="{{ option.value }}" selected>{{ option.label }}</option>
-              {% else %}
-              <option value="{{ option.value }}">{{ option.label }}</option>
-              {% endif %}
-            {% endfor %}
-          </select>
-        </div>
-      </div>
-    </div>
+    <h3><a href="#section-{{ cwv_distribution_config.id }}" class="anchor"><span data-slot="cwv-distribution-title-metric">Core Web Vitals</span> histogram</a></h3>
+    <p class="descr">{{ cwv_distribution_config.description }}</p>
+    <h4 class="heading">Latest data: <span data-slot="cwv-distribution-timestamp"></span></h4>
+    {% include "techreport/components/filter_meta.html" %}
   </div>
 
   <div id="{{ cwv_distribution_config.id }}-chart"></div>

--- a/templates/techreport/components/geo_breakdown.html
+++ b/templates/techreport/components/geo_breakdown.html
@@ -1,9 +1,5 @@
 {% set geo_breakdown_config = tech_report_page.config.geo_breakdown %}
 
-<button class="btn show-table geo-breakdown-toggle" type="button" id="geo-breakdown-btn">
-  Show geographic breakdown
-</button>
-
 <div
   id="section-{{ geo_breakdown_config.id }}"
   class="geo-breakdown-wrapper hidden"
@@ -13,28 +9,8 @@
 >
   <div class="component-heading-wrapper">
     <div class="component-heading">
-      <h3><a href="#section-{{ geo_breakdown_config.id }}" class="anchor">{{ geo_breakdown_config.title }}</a></h3>
+      <h3><a href="#section-{{ geo_breakdown_config.id }}" class="anchor"><span data-slot="geo-title-metric">Core Web Vitals</span> geographic breakdown</a></h3>
       <p class="descr">{{ geo_breakdown_config.description }}</p>
-    </div>
-
-    <div class="component-filters">
-      <div class="subcategory-selector-wrapper">
-        <div class="position-wrapper">
-          <label for="geo-metric-selector-{{ geo_breakdown_config.id }}">Metric</label>
-          <select
-            class="geo-metric-selector"
-            id="geo-metric-selector-{{ geo_breakdown_config.id }}"
-          >
-            {% for option in geo_breakdown_config.metric_options %}
-              {% if option.value == 'overall' %}
-              <option value="{{ option.value }}" selected>{{ option.label }}</option>
-              {% else %}
-              <option value="{{ option.value }}">{{ option.label }}</option>
-              {% endif %}
-            {% endfor %}
-          </select>
-        </div>
-      </div>
     </div>
   </div>
 

--- a/templates/techreport/components/geo_breakdown.html
+++ b/templates/techreport/components/geo_breakdown.html
@@ -1,7 +1,12 @@
 {% set geo_breakdown_config = tech_report_page.config.geo_breakdown %}
 
+<button class="btn show-table geo-breakdown-toggle" type="button" id="geo-breakdown-btn">
+  Show geographic breakdown
+</button>
+
 <div
   id="section-{{ geo_breakdown_config.id }}"
+  class="geo-breakdown-wrapper hidden"
   data-id="{{ geo_breakdown_config.id }}"
   data-component="geoBreakdown"
   data-client="{{ request.args.get('client', '') or 'mobile' }}"

--- a/templates/techreport/drilldown.html
+++ b/templates/techreport/drilldown.html
@@ -108,6 +108,12 @@
                     if (other !== panel && !other.wrapper.classList.contains('hidden')) {
                       other.wrapper.classList.add('hidden');
                       other.btn.textContent = other.showText;
+                      // As table doesn't set the hash, clear it to avoid showing old value
+                      if (window.location.hash) {
+                        const url = new URL(window.location.href);
+                        url.hash = '';
+                        window.history.replaceState(null, null, url);
+                      }
                     }
                   });
                 }, true);

--- a/templates/techreport/drilldown.html
+++ b/templates/techreport/drilldown.html
@@ -72,37 +72,45 @@
           <div class="cwv-button-bar">
             <button class="btn show-table cwv-show-table-btn" type="button" data-id="{{ ts_id }}">Show table</button>
             {% if tech_report_page.config.geo_breakdown %}
-              {% include "techreport/components/geo_breakdown.html" %}
+            <button class="btn show-table geo-breakdown-toggle" type="button" id="geo-breakdown-btn">Show geographic breakdown</button>
             {% endif %}
             {% if tech_report_page.config.cwv_distribution %}
-              {% include "techreport/components/cwv_distribution.html" %}
+            <button class="btn show-table cwv-distribution-toggle" type="button" id="cwv-distribution-btn">Show histogram</button>
             {% endif %}
           </div>
+
+          {% if tech_report_page.config.geo_breakdown %}
+            {% include "techreport/components/geo_breakdown.html" %}
+          {% endif %}
+          {% if tech_report_page.config.cwv_distribution %}
+            {% include "techreport/components/cwv_distribution.html" %}
+          {% endif %}
+
           <script nonce="{{ csp_nonce() }}">
             (function() {
               var bar = document.querySelector('.cwv-button-bar');
               var tw = document.getElementById('{{ ts_id }}-table-wrapper');
 
-              // Move table wrapper after the button bar so expanding it doesn't push buttons down
-              if (bar && tw) bar.after(tw);
+              // Move the timeseries' table wrapper out of the timeseries div so expanding it
+              // doesn't push the button bar down
+              if (bar && tw) bar.parentNode.insertBefore(tw, bar.nextSibling);
 
               // Mutual exclusion: only one panel open at a time
               var panels = [
-                { btn: bar.querySelector('.cwv-show-table-btn'), wrapper: tw, showText: 'Show table', hideText: 'Hide table' },
-                { btn: document.getElementById('geo-breakdown-btn'), wrapper: document.getElementById('section-geo_breakdown'), showText: 'Show geographic breakdown', hideText: 'Hide geographic breakdown' },
-                { btn: document.getElementById('cwv-distribution-btn'), wrapper: document.getElementById('section-cwv_distribution'), showText: 'Show distribution', hideText: 'Hide distribution' }
+                { btn: bar.querySelector('.cwv-show-table-btn'), wrapper: tw, showText: 'Show table' },
+                { btn: document.getElementById('geo-breakdown-btn'), wrapper: document.getElementById('section-geo_breakdown'), showText: 'Show geographic breakdown' },
+                { btn: document.getElementById('cwv-distribution-btn'), wrapper: document.getElementById('section-cwv_distribution'), showText: 'Show histogram' }
               ].filter(function(p) { return p.btn && p.wrapper; });
 
               panels.forEach(function(panel) {
                 panel.btn.addEventListener('click', function() {
-                  // Close other panels
                   panels.forEach(function(other) {
                     if (other !== panel && !other.wrapper.classList.contains('hidden')) {
                       other.wrapper.classList.add('hidden');
                       other.btn.textContent = other.showText;
                     }
                   });
-                }, true); // capture phase — runs before component handlers
+                }, true);
               });
             })();
           </script>

--- a/templates/techreport/drilldown.html
+++ b/templates/techreport/drilldown.html
@@ -67,13 +67,46 @@
           {% set timeseries = tech_report_page.config.good_cwv_timeseries %}
           {% set selected_subcategory = request.args.get('good-cwv-over-time', '') or tech_report_page.config.good_cwv_timeseries.viz.default or 'overall' %}
           {% include "techreport/components/timeseries.html" %}
-        </div>
 
-        {% if tech_report_page.config.geo_breakdown %}
-        <div class="card">
-          {% include "techreport/components/geo_breakdown.html" %}
+          {% set ts_id = tech_report_page.config.good_cwv_timeseries.id %}
+          <div class="cwv-button-bar">
+            <button class="btn show-table cwv-show-table-btn" type="button" data-id="{{ ts_id }}">Show table</button>
+            {% if tech_report_page.config.geo_breakdown %}
+              {% include "techreport/components/geo_breakdown.html" %}
+            {% endif %}
+            {% if tech_report_page.config.cwv_distribution %}
+              {% include "techreport/components/cwv_distribution.html" %}
+            {% endif %}
+          </div>
+          <script nonce="{{ csp_nonce() }}">
+            (function() {
+              var bar = document.querySelector('.cwv-button-bar');
+              var tw = document.getElementById('{{ ts_id }}-table-wrapper');
+
+              // Move table wrapper after the button bar so expanding it doesn't push buttons down
+              if (bar && tw) bar.after(tw);
+
+              // Mutual exclusion: only one panel open at a time
+              var panels = [
+                { btn: bar.querySelector('.cwv-show-table-btn'), wrapper: tw, showText: 'Show table', hideText: 'Hide table' },
+                { btn: document.getElementById('geo-breakdown-btn'), wrapper: document.getElementById('section-geo_breakdown'), showText: 'Show geographic breakdown', hideText: 'Hide geographic breakdown' },
+                { btn: document.getElementById('cwv-distribution-btn'), wrapper: document.getElementById('section-cwv_distribution'), showText: 'Show distribution', hideText: 'Hide distribution' }
+              ].filter(function(p) { return p.btn && p.wrapper; });
+
+              panels.forEach(function(panel) {
+                panel.btn.addEventListener('click', function() {
+                  // Close other panels
+                  panels.forEach(function(other) {
+                    if (other !== panel && !other.wrapper.classList.contains('hidden')) {
+                      other.wrapper.classList.add('hidden');
+                      other.btn.textContent = other.showText;
+                    }
+                  });
+                }, true); // capture phase — runs before component handlers
+              });
+            })();
+          </script>
         </div>
-        {% endif %}
       </div>
 
       <!-- Section: Lighthouse -->

--- a/templates/techreport/techreport.html
+++ b/templates/techreport/techreport.html
@@ -112,6 +112,7 @@
   <!-- Import general JS -->
   <script src="{{ get_versioned_filename('/static/js/techreport/timeseries.js') }}" nonce="{{ csp_nonce() }}"></script>
   <script src="{{ get_versioned_filename('/static/js/techreport/geoBreakdown.js') }}" nonce="{{ csp_nonce() }}"></script>
+  <script src="{{ get_versioned_filename('/static/js/techreport/cwvDistribution.js') }}" nonce="{{ csp_nonce() }}"></script>
   <script src="{{ get_versioned_filename('/static/js/techreport/section.js') }}" nonce="{{ csp_nonce() }}"></script>
   <script src="{{ get_versioned_filename('/static/js/techreport.js') }}" nonce="{{ csp_nonce() }}"></script>
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -16,6 +16,7 @@ module.exports = {
     'techreport/timeseries': './src/js/techreport/timeseries.js',
     'techreport/section': './src/js/techreport/section.js',
     'techreport/geoBreakdown': './src/js/techreport/geoBreakdown.js',
+    'techreport/cwvDistribution': './src/js/techreport/cwvDistribution.js',
   },
   output: {
     path: path.resolve(__dirname, 'static/js'),


### PR DESCRIPTION
## Summary

Adds two collapsible panels below the Core Web Vitals timeseries chart:

- **Histogram** — distribution of origins across performance buckets for the selected metric, with good/needs-improvement/poor color zones, threshold plotlines, and an overflow bucket for the long tail
- **Geographic breakdown** — existing section, moved here as a toggle

Both panels share a single button bar (alongside `Show table`) with mutual exclusion — opening one closes the other. Content is lazy-loaded on first open.

The metric selector from the pass-rate timeseries now drives all three components (timeseries, geo breakdown, histogram) via a shared `cwv-metric-change` event and the `good-cwv-over-time` URL param. Deep-linking with `?good-cwv-over-time=CLS` applies to all three. Titles update dynamically (`LCP histogram`, `INP geographic breakdown`, etc.). The histogram resolves `overall` to `LCP` since it shows one metric at a time.

Also scopes the global `.highcharts-point` CSS rule to line/spline series only, so column chart bar colors render correctly.

## Depends on

- HTTPArchive/tech-report-apis#105 — adds the `/v1/cwv-distribution` BigQuery endpoint

Closes #1147